### PR TITLE
Fix extraction of streams from DetectorToDaqConnection

### DIFF
--- a/include/datahandlinglibs/detail/FakeCardReaderBase.hxx
+++ b/include/datahandlinglibs/detail/FakeCardReaderBase.hxx
@@ -62,21 +62,14 @@ FakeCardReaderBase::do_conf(const nlohmann::json& /*args*/)
   if (m_configured) {
     TLOG_DEBUG(dunedaq::datahandlinglibs::logging::TLVL_WORK_STEPS) << "This module is already configured!";
   } else {
-    auto cfg = m_cfg->module<appmodel::DataReaderModule>(get_fcr_name());
+      auto cfg = m_cfg->module<appmodel::DataReaderModule>(get_fcr_name());
 
     std::map<uint32_t, const confmodel::DetectorStream*> streams;
     for (const auto & det_connections : cfg->get_connections()) {
       	    
-      for (const auto& det_res : det_connections->get_contains()) {
-	const confmodel::DetDataSender *data_sender = det_res->cast<confmodel::DetDataSender>();
-        if (data_sender != nullptr) {
-	  for (const auto& det_stream : data_sender->get_contains()) {	
-            auto dro_stream = det_stream->cast<confmodel::DetectorStream>();
-            if (dro_stream != nullptr) {
-              streams[dro_stream->get_source_id()] = dro_stream;
-            } 
-	  }
-	}
+      for (const auto& stream : det_connections->get_streams()) {
+          std::cout << "Adding stream " << stream->UID() << " source_id " << stream->get_source_id() << "\n";
+        streams[stream->get_source_id()] = stream;
       }
     }
 
@@ -93,6 +86,9 @@ FakeCardReaderBase::do_conf(const nlohmann::json& /*args*/)
         TLOG() << "Emulator for queue name " << q_with_id->UID() << " was already configured";
         throw datahandlinglibs::GenericConfigurationError(ERS_HERE, "Emulator configured twice: " + q_with_id->UID());
       }
+
+      std::cout << "Looking for stream " << q_with_id->get_source_id() << "\n";
+
       m_source_emus[q_with_id->UID()]->conf(streams[q_with_id->get_source_id()], cfg->get_configuration()->get_emulation_conf());
     }
     for (auto& [name, emu] : m_source_emus) {

--- a/include/datahandlinglibs/detail/FakeCardReaderBase.hxx
+++ b/include/datahandlinglibs/detail/FakeCardReaderBase.hxx
@@ -68,7 +68,6 @@ FakeCardReaderBase::do_conf(const nlohmann::json& /*args*/)
     for (const auto & det_connections : cfg->get_connections()) {
       	    
       for (const auto& stream : det_connections->get_streams()) {
-          std::cout << "Adding stream " << stream->UID() << " source_id " << stream->get_source_id() << "\n";
         streams[stream->get_source_id()] = stream;
       }
     }
@@ -86,9 +85,6 @@ FakeCardReaderBase::do_conf(const nlohmann::json& /*args*/)
         TLOG() << "Emulator for queue name " << q_with_id->UID() << " was already configured";
         throw datahandlinglibs::GenericConfigurationError(ERS_HERE, "Emulator configured twice: " + q_with_id->UID());
       }
-
-      std::cout << "Looking for stream " << q_with_id->get_source_id() << "\n";
-
       m_source_emus[q_with_id->UID()]->conf(streams[q_with_id->get_source_id()], cfg->get_configuration()->get_emulation_conf());
     }
     for (auto& [name, emu] : m_source_emus) {


### PR DESCRIPTION
FakeCardReaderBase was not handling `DetectorToDaqConnection` objects that contain `DetDataSenders` indirectly through a `ResourceSetAND`. Use `DetectorToDaqConnection::get_streams()` method to get streams rather than manually decode.