### PR TITLE
correct timeout handling for resubmitting a data request

### DIFF
--- a/include/datahandlinglibs/concepts/RequestHandlerConcept.hpp
+++ b/include/datahandlinglibs/concepts/RequestHandlerConcept.hpp
@@ -51,7 +51,7 @@ public:
   virtual void periodic_data_transmission() = 0;
 
   //! Issue a data request to the request handler
-  virtual void issue_request(dfmessages::DataRequest /*dr*/) = 0;
+  virtual void issue_request(dfmessages::DataRequest /*dr*/, bool /*is_retry*/) = 0;
 
 
 protected:

--- a/include/datahandlinglibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/datahandlinglibs/models/DefaultRequestHandlerModel.hpp
@@ -150,7 +150,7 @@ public:
   virtual void periodic_data_transmission() override;
 
   // Implementation of default request handling. (boost::asio post to a thread pool)
-  void issue_request(dfmessages::DataRequest datarequest) override;
+  void issue_request(dfmessages::DataRequest datarequest, bool is_retry=false) override;
 
   // Opmon get_info implementation
   // void get_info(opmonlib::InfoCollector& ci, int /*level*/) override;

--- a/include/datahandlinglibs/models/EmptyFragmentRequestHandlerModel.hpp
+++ b/include/datahandlinglibs/models/EmptyFragmentRequestHandlerModel.hpp
@@ -44,7 +44,7 @@ public:
 
   // Override the issue_request implementation of the DefaultRequestHandlerModel
   // in order to always respond with empty fragments. 
-  void issue_request(dfmessages::DataRequest datarequest) override;
+  void issue_request(dfmessages::DataRequest datarequest, bool is_retry=false) override;
 
 };
 

--- a/include/datahandlinglibs/models/detail/EmptyFragmentRequestHandlerModel.hxx
+++ b/include/datahandlinglibs/models/detail/EmptyFragmentRequestHandlerModel.hxx
@@ -8,7 +8,7 @@ namespace datahandlinglibs {
 template<class ReadoutType, class LatencyBufferType>
 void 
 EmptyFragmentRequestHandlerModel<ReadoutType, LatencyBufferType>::issue_request(
-  dfmessages::DataRequest datarequest)
+  dfmessages::DataRequest datarequest, bool is_retry)
 {
   auto frag_header = inherited::create_fragment_header(datarequest);
   frag_header.error_bits |= (0x1 << static_cast<size_t>(daqdataformats::FragmentErrorBits::kDataNotFound));


### PR DESCRIPTION
This PR aims at fixing issue #21. 
a re-queued request is checked every 1 ms for those two conditions:
- the latency buffer contains data that are newer than the end timestamp of the data request;
- the timeout has been reached
If either of the conditions is reached the data fragment is created and sent back to the requester.

Also, requests are now resubmitted only once.