### PR TITLE
DataHandlingModel with IDT

### DIFF
--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -59,7 +59,7 @@ using dunedaq::datahandlinglibs::logging::TLVL_WORK_STEPS;
 namespace dunedaq {
 namespace datahandlinglibs {
 
-template<class ReadoutType, class RequestHandlerType, class LatencyBufferType, class RawDataProcessorType>
+template<class ReadoutType, class RequestHandlerType, class LatencyBufferType, class RawDataProcessorType, class InputDataType = ReadoutType>
 class DataHandlingModel : public DataHandlingConcept
 {
 public:
@@ -68,6 +68,7 @@ public:
   using RHT = RequestHandlerType;
   using LBT = LatencyBufferType;
   using RPT = RawDataProcessorType;
+  using IDT = InputDataType;
 
   // Using timestamp typenames
   using timestamp_t = std::uint64_t; // NOLINT(build/unsigned)
@@ -139,6 +140,11 @@ protected:
   // Dispatch data request
   void dispatch_requests(dfmessages::DataRequest& data_request);
 
+  // Transform input data type to readout
+  RDT& transform_payload(IDT& payload) const
+  {
+    return reinterpret_cast<RDT&>(payload);
+  }
 
   // Operational monitoring
   virtual void generate_opmon_data() override;
@@ -170,7 +176,7 @@ protected:
   // RAW RECEIVER
   std::chrono::milliseconds m_raw_receiver_timeout_ms;
   std::chrono::microseconds m_raw_receiver_sleep_us;
-  using raw_receiver_ct = iomanager::ReceiverConcept<ReadoutType>;
+  using raw_receiver_ct = iomanager::ReceiverConcept<InputDataType>;
   std::shared_ptr<raw_receiver_ct> m_raw_data_receiver;
   std::string m_raw_data_receiver_connection_name;
 

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -94,6 +94,8 @@ public:
     m_pid_of_current_process = getpid();
   }
 
+  virtual ~DataHandlingModel() = default;
+
   // Initializes the readoutmodel and its internals
   void init(const appmodel::DataHandlerModule* modconf);
 
@@ -130,7 +132,10 @@ public:
   std::function<void(RDT&&)> m_consume_callback;
 
 protected:
- 
+
+  // Perform processing operations on payload
+  void process_item(RDT& payload);
+  
   // Raw data consumer's work function
   void run_consume();
 
@@ -139,11 +144,14 @@ protected:
 
   // Dispatch data request
   void dispatch_requests(dfmessages::DataRequest& data_request);
-
+  
   // Transform input data type to readout
-  RDT& transform_payload(IDT& payload) const
+  virtual std::unique_ptr<RDT[]> transform_payload(IDT& original, std::size_t& size) const
   {
-    return reinterpret_cast<RDT&>(payload);
+    size = 1;
+    auto transformed = std::make_unique_for_overwrite<RDT[]>(size);
+    transformed[0] = reinterpret_cast<RDT&>(original);
+    return transformed;
   }
 
   // Operational monitoring

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -146,12 +146,9 @@ protected:
   void dispatch_requests(dfmessages::DataRequest& data_request);
   
   // Transform input data type to readout
-  virtual std::unique_ptr<RDT[]> transform_payload(IDT& original, std::size_t& size) const
+  virtual std::vector<RDT> transform_payload(IDT& original) const
   {
-    size = 1;
-    auto transformed = std::make_unique_for_overwrite<RDT[]>(size);
-    transformed[0] = reinterpret_cast<RDT&>(original);
-    return transformed;
+    return { reinterpret_cast<RDT&>(original) };
   }
 
   // Operational monitoring

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -251,10 +251,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
       if constexpr (std::is_same_v<IDT, RDT>) {
         process_item(original);
       } else {
-        std::size_t size;
-        auto transformed = transform_payload(original, size);
-        for(auto i = 0; i < size; ++i) {
-          process_item(transformed[i]);
+        auto transformed = transform_payload(original);
+        for (auto& i : transformed) {
+          process_item(i);
         }   
       }
     } else {


### PR DESCRIPTION
A new template parameter `InputDataType` is added to `DataHandlingModel`. Before preprocessing, it is transformed to `ReadoutType` by a call to the new function `transform_payload`which currently is a simple `reinterpret_cast`.

[trigger pull request](https://github.com/DUNE-DAQ/trigger/pull/362)
[appmodel pull request](https://github.com/DUNE-DAQ/appmodel/pull/155)
[fdreadoutlibs pull request](https://github.com/DUNE-DAQ/fdreadoutlibs/pull/240)

[JIRA task](https://its.cern.ch/jira/browse/EPDTDI-1502)