### PR TITLE
DataMoveCallbackRegistry::get_callback must throw if cast fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,9 @@ daq_add_application(datahandlinglibs_test_composite_key test_composite_key_app.c
 ##############################################################################
 # Unit Tests
 
-daq_add_unit_test(datahandlinglibs_BufferedReadWrite_test LINK_LIBRARIES datahandlinglibs ${BOOST_LIBS})
+#daq_add_unit_test(datahandlinglibs_BufferedReadWrite_test LINK_LIBRARIES datahandlinglibs ${BOOST_LIBS})
 #daq_add_unit_test(datahandlinglibs_VariableSizeElementQueue_test LINK_LIBRARIES datahandlinglibs ${BOOST_LIBS})
+daq_add_unit_test(datahandlinglibs_DataMoveCallbackRegistry_test LINK_LIBRARIES datahandlinglibs ${BOOST_LIBS})
 
 ##############################################################################
 # Installation

--- a/include/datahandlinglibs/DataMoveCallbackRegistry.hpp
+++ b/include/datahandlinglibs/DataMoveCallbackRegistry.hpp
@@ -61,6 +61,14 @@ public:
   template<typename DataType>
   void register_callback(const std::string& id, std::function<void(DataType&&)> callback);
  
+  /**
+   * @brief Gets the callback function registered with the given ID
+   * 
+   * @tparam DataType The expected parameter type of the callback function
+   * @param id The unique identifier for the callback
+   * @return A shared pointer to the callback function
+   * @throw GenericConfigurationError if the registered callback function's parameter type does not match `DataType`
+   */
   template<typename DataType>
   std::shared_ptr<std::function<void(DataType&&)>>
   get_callback(const std::string& id);

--- a/include/datahandlinglibs/detail/DataMoveCallbackRegistry.hxx
+++ b/include/datahandlinglibs/detail/DataMoveCallbackRegistry.hxx
@@ -1,3 +1,5 @@
+#include "datahandlinglibs/DataHandlingIssues.hpp"
+
 #include <functional>
 
 namespace dunedaq {
@@ -5,7 +7,7 @@ namespace dunedaq {
 namespace datahandlinglibs {
 
 template<typename DataType>
-inline void 
+inline void
 DataMoveCallbackRegistry::register_callback(const std::string& id, std::function<void(DataType&&)> callback) {
   if (m_callback_map.count(id) == 0) {
     TLOG() << "Registering DataMoveCallback with ID: " << id;
@@ -17,11 +19,20 @@ DataMoveCallbackRegistry::register_callback(const std::string& id, std::function
 
 template<typename DataType>
 inline std::shared_ptr<std::function<void(DataType&&)>>
-DataMoveCallbackRegistry::get_callback(const std::string& id) {
-  if (m_callback_map.count(id) != 0) {
+DataMoveCallbackRegistry::get_callback(const std::string& id)
+{
+  if (m_callback_map.contains(id)) {
     TLOG() << "Providing DataMoveCallback with ID: " << id;
-    auto callback = dynamic_cast<DataMoveCallback<DataType>*>(m_callback_map[id].get());
-    return callback->m_callback;
+    if (auto callback = dynamic_cast<DataMoveCallback<DataType>*>(m_callback_map[id].get()); callback != nullptr) {
+      return callback->m_callback;
+    } else {
+      // As this can happen due to a very bad config error and wherever the acquire is called will lead to undefined behavior
+      throw GenericConfigurationError(
+        ERS_HERE,
+        std::format("Callback cast failed for function signature with datatypes (expected vs. registered) : {} vs. {}",
+                    typeid(DataMoveCallback<DataType>).name(),
+                    typeid(*m_callback_map[id]).name()));
+    }
   } else {
     TLOG() << "No callback registered with ID: " << id << " Returning nullptr.";
     return nullptr;
@@ -30,4 +41,3 @@ DataMoveCallbackRegistry::get_callback(const std::string& id) {
 
 }
 }
-

--- a/unittest/datahandlinglibs_DataMoveCallbackRegistry_test.cxx
+++ b/unittest/datahandlinglibs_DataMoveCallbackRegistry_test.cxx
@@ -1,0 +1,46 @@
+/**
+ * @file datahandlinglibs_DataMoveCallbackRegistry_test.cxx Unit tests for DataMoveCallbackRegistry
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+/**
+ * @brief Name of this test module
+ */
+#define BOOST_TEST_MODULE datahandlinglibs_DataMoveCallbackRegistry_test // NOLINT
+
+#include "datahandlinglibs/DataMoveCallbackRegistry.hpp"
+
+#include "boost/test/unit_test.hpp"
+
+using namespace dunedaq::datahandlinglibs;
+
+BOOST_AUTO_TEST_SUITE(datahandlinglibs_DataMoveCallbackRegistry_test)
+
+/**
+ * @brief Tests for DataMoveCallbackRegistry singleton
+ */
+BOOST_AUTO_TEST_CASE(DataMoveCallbackRegistry_get_callback)
+{
+  auto registry = DataMoveCallbackRegistry::get();
+
+  /**
+   * @test No callback function registered with the given ID
+   */
+  BOOST_CHECK(registry->get_callback<int>("id") == nullptr);
+
+  /**
+   * @test A registered callback function can be retrieved
+   */
+  registry->register_callback<int>("id", [](int&&) {});
+  BOOST_CHECK(registry->get_callback<int>("id") != nullptr);
+
+  /**
+   * @test The registered callback function's parameter type and template argument must match
+   */
+  BOOST_CHECK_THROW(registry->get_callback<double>("id"), GenericConfigurationError);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
https://github.com/DUNE-DAQ/datahandlinglibs/issues/43