### PR TITLE
Removed the include of the now-deprecated appfwk/Issues.hpp header fr…

### DIFF
--- a/include/datahandlinglibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/datahandlinglibs/models/DefaultRequestHandlerModel.hpp
@@ -24,7 +24,6 @@
 #include "appmodel/LatencyBuffer.hpp"
 #include "appmodel/DataRecorderConf.hpp"
 
-#include "appfwk/Issues.hpp"
 #include "dfmessages/Fragment_serialization.hpp"
 #include "daqdataformats/Types.hpp"
 #include "dfmessages/DataRequest.hpp"


### PR DESCRIPTION
…om DefaultRequestHandlerModel.hpp

Without this change, we see a compiler warning about this header file being deprecated (starting with the 09-Apr nightly build).

With this change, that compiler warning does not appear.