### PR TITLE
Added a warning message to DataHandlingModel to let users know about …

### DIFF
--- a/include/datahandlinglibs/DataHandlingIssues.hpp
+++ b/include/datahandlinglibs/DataHandlingIssues.hpp
@@ -185,8 +185,8 @@ ERS_DECLARE_ISSUE(datahandlinglibs,
                   ((daqdataformats::run_number_t)run)((daqdataformats::timestamp_t)ts1)((daqdataformats::timestamp_t)ts2)((int64_t)tick_diff)((double)msec_diff))
 
 ERS_DECLARE_ISSUE(datahandlinglibs,
-                  NonZeroOverWrittenDataPackets,
-                  "There were " << fail_count << " failures to write data to the latency buffer out of " <<
+                  NonZeroLatencyBufferInsertFailures,
+                  "There were " << fail_count << " failures to insert data into the latency buffer out of " <<
                   total_count << " attempts in the latest monitoring interval.",
                   ((int64_t)fail_count)((int64_t)total_count))
 

--- a/include/datahandlinglibs/DataHandlingIssues.hpp
+++ b/include/datahandlinglibs/DataHandlingIssues.hpp
@@ -185,6 +185,12 @@ ERS_DECLARE_ISSUE(datahandlinglibs,
                   ((daqdataformats::run_number_t)run)((daqdataformats::timestamp_t)ts1)((daqdataformats::timestamp_t)ts2)((int64_t)tick_diff)((double)msec_diff))
 
 ERS_DECLARE_ISSUE(datahandlinglibs,
+                  NonZeroOverWrittenDataPackets,
+                  "There were " << fail_count << " failures to write data to the latency buffer out of " <<
+                  total_count << " attempts in the latest monitoring interval.",
+                  ((int64_t)fail_count)((int64_t)total_count))
+
+ERS_DECLARE_ISSUE(datahandlinglibs,
                   NewErrorRegistered,
                   ers_metadata << "New error registered with \"" << error_name << "\"",
                   ((std::string)ers_metadata) ((std::string)error_name))

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -174,14 +174,14 @@ protected:
   using num_request_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_requests),metric_t>::type>::type;
   using sum_request_t = std::remove_const<std::invoke_result<decltype(&metric_t::sum_requests),metric_t>::type>::type;
   using rawq_timeout_count_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_data_input_timeouts),metric_t>::type>::type;
-  using num_payloads_overwritten_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_payloads_overwritten),metric_t>::type>::type;
+  using num_lb_insert_failures_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_lb_insert_failures),metric_t>::type>::type;
 
   std::atomic<num_payload_t> m_num_payloads{ 0 };
   std::atomic<sum_payload_t> m_sum_payloads{ 0 };
   std::atomic<num_request_t> m_num_requests{ 0 };
   std::atomic<sum_request_t> m_sum_requests{ 0 };
   std::atomic<rawq_timeout_count_t> m_rawq_timeout_count{ 0 };
-  std::atomic<num_payloads_overwritten_t> m_num_payloads_overwritten{ 0 };
+  std::atomic<num_lb_insert_failures_t> m_num_lb_insert_failures{ 0 };
   std::atomic<int> m_stats_packet_count{ 0 };
 
   // CONSUMER

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -184,8 +184,15 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
    double seconds = std::chrono::duration_cast<std::chrono::microseconds>(now - m_t0).count() / 1000000.;
    m_t0 = now;
 
+   // 08-May-2025, KAB: added a message to warn users when payloads are being overwritten.
+   // "overwritten" means that they failed to be added to the latency buffer.
+   int local_num_payloads_overwritten = m_num_payloads_overwritten.exchange(0);
+   if (local_num_payloads_overwritten != 0) {
+     ers::warning(NonZeroOverWrittenDataPackets(ERS_HERE, local_num_payloads_overwritten, ri.num_payloads()));
+   }
+
    ri.set_rate_payloads_consumed(new_packets / seconds / 1000.);
-   ri.set_num_payloads_overwritten(m_num_payloads_overwritten.exchange(0));
+   ri.set_num_payloads_overwritten(local_num_payloads_overwritten);
    ri.set_sum_requests(m_sum_requests.load());
    ri.set_num_requests(m_num_requests.exchange(0));
    ri.set_last_daq_timestamp(m_raw_processor_impl->get_last_daq_time());

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -123,7 +123,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const nlohmann::json& args)
   m_num_payloads = 0;
   m_sum_requests = 0;
   m_num_requests = 0;
-  m_num_payloads_overwritten = 0;
+  m_num_lb_insert_failures = 0;
   m_stats_packet_count = 0;
   m_rawq_timeout_count = 0;
 
@@ -184,15 +184,14 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
    double seconds = std::chrono::duration_cast<std::chrono::microseconds>(now - m_t0).count() / 1000000.;
    m_t0 = now;
 
-   // 08-May-2025, KAB: added a message to warn users when payloads are being overwritten.
-   // "overwritten" means that they failed to be added to the latency buffer.
-   int local_num_payloads_overwritten = m_num_payloads_overwritten.exchange(0);
-   if (local_num_payloads_overwritten != 0) {
-     ers::warning(NonZeroOverWrittenDataPackets(ERS_HERE, local_num_payloads_overwritten, ri.num_payloads()));
+   // 08-May-2025, KAB: added a message to warn users when latency buffer inserts are failing.
+   int local_num_lb_insert_failures = m_num_lb_insert_failures.exchange(0);
+   if (local_num_lb_insert_failures != 0) {
+     ers::warning(NonZeroLatencyBufferInsertFailures(ERS_HERE, local_num_lb_insert_failures, ri.num_payloads()));
    }
 
    ri.set_rate_payloads_consumed(new_packets / seconds / 1000.);
-   ri.set_num_payloads_overwritten(local_num_payloads_overwritten);
+   ri.set_num_lb_insert_failures(local_num_lb_insert_failures);
    ri.set_sum_requests(m_sum_requests.load());
    ri.set_num_requests(m_num_requests.exchange(0));
    ri.set_last_daq_timestamp(m_raw_processor_impl->get_last_daq_time());
@@ -216,7 +215,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT& payload)
   }
   if (!m_latency_buffer_impl->write(std::move(payload))) {
     //TLOG_DEBUG(TLVL_TAKE_NOTE) << "***ERROR: Latency buffer is full and data was overwritten!";
-    m_num_payloads_overwritten++;
+    m_num_lb_insert_failures++;
   }
   if (m_processing_delay_ticks ==0) {
     m_raw_processor_impl->postprocess_item(m_latency_buffer_impl->back());
@@ -329,7 +328,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::consume_payload(RDT&& payload)
   }
   if (!m_latency_buffer_impl->write(std::move(payload))) {
     TLOG_DEBUG(TLVL_TAKE_NOTE) << "***ERROR: Latency buffer is full and data was overwritten!";
-    m_num_payloads_overwritten++;
+    m_num_lb_insert_failures++;
   }
 #warning RS FIXME: Post-processing delay feature is not implemented in callback consume!
   m_raw_processor_impl->postprocess_item(m_latency_buffer_impl->back());

--- a/schema/datahandlinglibs/opmon/datahandling_info.proto
+++ b/schema/datahandlinglibs/opmon/datahandling_info.proto
@@ -17,7 +17,7 @@ message DataHandlerInfo {
   uint64 num_payloads = 2; // Incremental number of received payloads 
   uint64 num_data_input_timeouts = 3; // Timeout on data inputs 
   double rate_payloads_consumed = 4; // Rate of consumed packets 
-  uint64 num_payloads_overwritten = 5; // Number of overwritten payloads because the LB is full 
+  uint64 num_lb_insert_failures = 5; // Number of failures to insert data into the LB
   uint64 sum_requests = 11; // Total number of received requests 
   uint64 num_requests = 12; // Incremental number of received requests 
   uint64 last_daq_timestamp = 21; // Most recent DAQ timestamp processed 


### PR DESCRIPTION
…failures to write payloads into the latency buffer.

I have chosen to put this warning message in the generate_opmon_data() method so that it only gets produced occasionally (and certainly not every time a write into the LB fails).

I realized the usefulness of such a warning message when I stumbled on a large number of write failures in DAPHNE TP regression tests.  In those tests, we currently don't look at opmon metrics (yet), so it will be very helpful to have a warning message that will get noticed.