### PR TITLE
Changed the severity of the ERS message in FileSourceBuffer that informs…

### DIFF
--- a/include/datahandlinglibs/DataHandlingIssues.hpp
+++ b/include/datahandlinglibs/DataHandlingIssues.hpp
@@ -52,6 +52,16 @@ ERS_DECLARE_ISSUE(datahandlinglibs,
                   "Configuration Error: " << conferror,
                   ((std::string)conferror))
 
+ERS_DECLARE_ISSUE(datahandlinglibs,
+                  FileHasExtraData,
+                  "Binary file contains extra data, " << numbytes
+                  << " bytes beyond an exact integer number of super-chunks. "
+                  << "This is not a problem and those bytes will be ignored, "
+                  << "filesize is " << filesize << ", "
+                  << "chunk_size is " << chunksize << ", "
+                  << "filename is " << filename,
+                  ((int32_t)numbytes)((size_t)filesize)((int32_t)chunksize)((std::string)filename))
+
 
 ERS_DECLARE_ISSUE(datahandlinglibs,
                   TimeSyncTransmissionFailed,

--- a/include/datahandlinglibs/utils/FileSourceBuffer.hpp
+++ b/include/datahandlinglibs/utils/FileSourceBuffer.hpp
@@ -65,12 +65,7 @@ public:
       if (m_chunk_size > 0) {
         int remainder = filesize % m_chunk_size;
         if (remainder > 0) {
-          std::ostringstream oss;
-          oss << "Binary file contains more data than expected, "
-              << "filesize is " << filesize << ", "
-              << "chunk_size is " << m_chunk_size << ", "
-              << "filename is " << m_source_filename;
-          ers::warning(GenericConfigurationError(ERS_HERE, oss.str()));
+          ers::info(FileHasExtraData(ERS_HERE, remainder, filesize, m_chunk_size, m_source_filename));
         }
         // Set usable element count
         m_element_count = filesize / m_chunk_size;


### PR DESCRIPTION
…users about extra data in binary files from warning to info, and modified the text of that message to make it clear that the extra data is not a fatal problem.

When users create binary files of data to be used for file-replay, they may not realize that they should include an integer number of super-chunks in those files.  When there is not an integer number of super-chunks, FileSourceBuffer emits a message.  Historically, that message has been a Warning, and that has often tripped up the running of automated regression tests because they expect there to be no warnings in log files.  The change in severity of the message will help avoid unnecessary regression test failures.

Here is a sample of the message from a logfile:
```
2025-May-21 10:29:36,995 INFO [void dunedaq::datahandlinglibs::FileSourceBuffer::read(const std::string&) at /home/nfs/biery/dunedaq/21MayFDDevMinorPRs/sourcecode/datahandlinglibs/include/datahandlinglibs/utils/FileSourceBuffer.hpp:68] Binary file contains extra data, 3 bytes beyond an exact integer number of super-chunks. This is not a problem and those bytes will be ignored, filesize is 230403, chunk_size is 7200, filename is /home/nfs/biery/dunedaq/21MayFDDevMinorPRs/sourcecode/daqsystemtest/integtest/wibeth_output_all_zeros.bin
```
