### PR TITLE
Update to work with new confmodel Resource schema

### DIFF
--- a/include/datahandlinglibs/detail/FakeCardReaderBase.hxx
+++ b/include/datahandlinglibs/detail/FakeCardReaderBase.hxx
@@ -52,7 +52,7 @@ FakeCardReaderBase::do_conf(const nlohmann::json& /*args*/)
     std::map<uint32_t, const confmodel::DetectorStream*> streams;
     for (const auto & det_connections : cfg->get_connections()) {
       	    
-      for (const auto& stream : det_connections->get_streams()) {
+      for (const auto& stream : det_connections->streams()) {
         streams[stream->get_source_id()] = stream;
       }
     }


### PR DESCRIPTION
Update to work with new confmodel Resource schema
Requires https://github.com/DUNE-DAQ/confmodel/pull/73

Update as DetectorToDaqConnection get_streams renamed to simply streams in latest confmodel
