### PR TITLE
Delayed postprocessing rework

### DIFF
--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -129,7 +129,7 @@ public:
   //void get_info(opmonlib::InfoCollector& ci, int level);
 
   // Raw data consume callback
-  void consume_payload(RDT&& payload);
+  void consume_payload(RDT&& payload);  
 
   // Consume callback
   std::function<void(RDT&&)> m_consume_callback;
@@ -145,11 +145,11 @@ protected:
   // Timesync thread's work function
   void run_timesync();
 
-  // Delayed postprocessing thread's work function
-  void run_delayed_postprocessing();
+  // Postprocess scheduler thread's work function
+  void run_postprocess_scheduler();
 
-  // Delayed postprocessing coroutine
-  folly::coro::Task<void> delayed_postprocessing();  
+  // Postprocess schedule coroutine
+  folly::coro::Task<void> postprocess_schedule();  
 
   // Dispatch data request
   void dispatch_requests(dfmessages::DataRequest& data_request);
@@ -210,8 +210,9 @@ protected:
   std::string m_timesync_connection_name;
   uint32_t m_pid_of_current_process;
 
-  // DELAYED POSTPROCESSING
-  utilities::ReusableThread m_delayed_postprocessing_thread;
+  // POSTPROCESS SCHEDULER
+  utilities::ReusableThread m_postprocess_scheduler_thread;
+  folly::coro::Baton m_baton;
 
   // LATENCY BUFFER
   std::shared_ptr<LatencyBufferType> m_latency_buffer_impl;
@@ -228,8 +229,6 @@ protected:
 
   // RUN START T0
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
-
-  folly::coro::Baton m_baton;
 };
 
 } // namespace datahandlinglibs

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -47,6 +47,7 @@
 
 #include <folly/coro/Baton.h>
 #include <folly/coro/Task.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
 
 #include <functional>
 #include <memory>
@@ -160,7 +161,7 @@ protected:
   // Operational monitoring
   virtual void generate_opmon_data() override;
 
-  // Constuctor params
+  // Constructor params
   std::atomic<bool>& m_run_marker;
 
   // CONFIGURATION
@@ -172,6 +173,8 @@ protected:
   daqdataformats::SourceID m_sourceid;
   daqdataformats::run_number_t m_run_number;
   uint64_t m_processing_delay_ticks;
+  uint64_t m_post_processing_delay_min_wait;
+  uint64_t m_post_processing_delay_max_wait;
 
   // STATS
   using metric_t = dunedaq::datahandlinglibs::opmon::DataHandlerInfo;
@@ -181,6 +184,7 @@ protected:
   using sum_request_t = std::remove_const<std::invoke_result<decltype(&metric_t::sum_requests),metric_t>::type>::type;
   using rawq_timeout_count_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_data_input_timeouts),metric_t>::type>::type;
   using num_lb_insert_failures_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_lb_insert_failures),metric_t>::type>::type;
+  using num_post_processing_delay_max_waits_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_post_processing_delay_max_waits),metric_t>::type>::type;
 
   std::atomic<num_payload_t> m_num_payloads{ 0 };
   std::atomic<sum_payload_t> m_sum_payloads{ 0 };
@@ -188,6 +192,7 @@ protected:
   std::atomic<sum_request_t> m_sum_requests{ 0 };
   std::atomic<rawq_timeout_count_t> m_rawq_timeout_count{ 0 };
   std::atomic<num_lb_insert_failures_t> m_num_lb_insert_failures{ 0 };
+  std::atomic<num_post_processing_delay_max_waits_t> m_num_post_processing_delay_max_waits{ 0 };
   std::atomic<int> m_stats_packet_count{ 0 };
 
   // CONSUMER
@@ -219,6 +224,7 @@ protected:
   // POSTPROCESS SCHEDULER
   utilities::ReusableThread m_postprocess_scheduler_thread;
   folly::coro::Baton m_baton;
+  std::unique_ptr<folly::ThreadWheelTimekeeper> m_timekeeper;
 
   // LATENCY BUFFER
   std::shared_ptr<LatencyBufferType> m_latency_buffer_impl;

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -45,6 +45,9 @@
 #include "datahandlinglibs/DataHandlingIssues.hpp"
 #include "utilities/ReusableThread.hpp"
 
+#include <folly/coro/Baton.h>
+#include <folly/coro/Task.h>
+
 #include <functional>
 #include <memory>
 #include <string>
@@ -142,6 +145,12 @@ protected:
   // Timesync thread's work function
   void run_timesync();
 
+  // Delayed postprocessing thread's work function
+  void run_delayed_postprocessing();
+
+  // Delayed postprocessing coroutine
+  folly::coro::Task<void> delayed_postprocessing();  
+
   // Dispatch data request
   void dispatch_requests(dfmessages::DataRequest& data_request);
   
@@ -201,6 +210,9 @@ protected:
   std::string m_timesync_connection_name;
   uint32_t m_pid_of_current_process;
 
+  // DELAYED POSTPROCESSING
+  utilities::ReusableThread m_delayed_postprocessing_thread;
+
   // LATENCY BUFFER
   std::shared_ptr<LatencyBufferType> m_latency_buffer_impl;
 
@@ -216,6 +228,8 @@ protected:
 
   // RUN START T0
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
+
+  folly::coro::Baton m_baton;
 };
 
 } // namespace datahandlinglibs

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -128,16 +128,13 @@ public:
   // Opmon get_info call implementation
   //void get_info(opmonlib::InfoCollector& ci, int level);
 
-  // Raw data consume callback
-  void consume_payload(RDT&& payload);  
-
   // Consume callback
   std::function<void(RDT&&)> m_consume_callback;
 
 protected:
 
   // Perform processing operations on payload
-  void process_item(RDT& payload);
+  void process_item(RDT&& payload);
   
   // Raw data consumer's work function
   void run_consume();

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -102,7 +102,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::conf(const nlohmann::json& /*args*/)
   // Register callbacks if operating in that mode.
   if (m_callback_mode) {
     // Configure and register consume callback
-    m_consume_callback = std::bind(&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::consume_payload, this, std::placeholders::_1);
+    m_consume_callback = std::bind(&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item, this, std::placeholders::_1);
  
     // Register callback
     auto dmcbr = DataMoveCallbackRegistry::get();
@@ -212,7 +212,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
 void 
-DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT& payload)
+DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT&& payload)
 {
   m_raw_processor_impl->preprocess_item(&payload);
   if (m_request_handler_supports_cutoff_timestamp) {
@@ -266,11 +266,11 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
       IDT& original = opt_payload.value();
       
       if constexpr (std::is_same_v<IDT, RDT>) {
-        process_item(original);
+        process_item(std::move(original));
       } else {
         auto transformed = transform_payload(original);
         for (auto& i : transformed) {
-          process_item(i);
+          process_item(std::move(i));
         }   
       }
     } else {
@@ -339,13 +339,6 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule() {
       }
     }
   }
-}
-
-template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void
-DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::consume_payload(RDT&& payload)
-{
-  process_item(payload);
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -1,6 +1,7 @@
 // Declarations for DataHandlingModel
 
 #include <folly/coro/BlockingWait.h>
+#include <folly/coro/Timeout.h>
 
 #include <typeinfo>
 
@@ -81,6 +82,8 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerModu
   m_sourceid.id = mcfg->get_source_id();
   m_sourceid.subsystem = RDT::subsystem;
   m_processing_delay_ticks = mcfg->get_module_configuration()->get_post_processing_delay_ticks();
+  m_post_processing_delay_min_wait = mcfg->get_module_configuration()->get_post_processing_delay_min_wait();
+  m_post_processing_delay_max_wait = mcfg->get_module_configuration()->get_post_processing_delay_max_wait();
   
 
   // Configure implementations:
@@ -116,6 +119,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::conf(const nlohmann::json& /*args*/)
   }
   if (m_processing_delay_ticks) {
     m_postprocess_scheduler_thread.set_name("pprocsched", m_sourceid.id);
+    m_timekeeper = std::make_unique<folly::ThreadWheelTimekeeper>();
   }  
 }
 
@@ -132,6 +136,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const nlohmann::json& args)
   m_num_lb_insert_failures = 0;
   m_stats_packet_count = 0;
   m_rawq_timeout_count = 0;
+  m_num_post_processing_delay_max_waits = 0;
 
   m_t0 = std::chrono::high_resolution_clock::now();
 
@@ -211,6 +216,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
    ri.set_num_lb_insert_failures(local_num_lb_insert_failures);
    ri.set_sum_requests(m_sum_requests.load());
    ri.set_num_requests(m_num_requests.exchange(0));
+   ri.set_num_post_processing_delay_max_waits(m_num_post_processing_delay_max_waits.exchange(0));
    ri.set_last_daq_timestamp(m_raw_processor_impl->get_last_daq_time());
 
    this->publish(std::move(ri));
@@ -261,6 +267,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
   m_num_payloads = 0;
   m_sum_payloads = 0;
   m_stats_packet_count = 0;
+  m_num_post_processing_delay_max_waits = 0;
 
   while (m_run_marker.load()) {
     // Try to acquire data
@@ -292,8 +299,8 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
 folly::coro::Task<void>
 DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule() {  
-  TLOG_DEBUG(TLVL_WORK_STEPS) << "Postprocess schedule coroutine started...";
 
+  TLOG_DEBUG(TLVL_WORK_STEPS) << "Postprocess schedule coroutine started...";
   timestamp_t newest_ts = 0;
   timestamp_t end_win_ts = 0;
   bool first_cycle = true;
@@ -305,8 +312,15 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule() {
   // Deferral of the post processing, to allow elements being reordered in the LB
   // Basically, find data older than a certain timestamp and process all data since the last post-processed element up to that value  
   while (m_run_marker.load()) {
-    co_await m_baton;
-    m_baton.reset();
+    try {
+      co_await folly::coro::timeout(
+        m_baton.operator co_await(),
+        std::chrono::milliseconds{m_post_processing_delay_max_wait},
+        m_timekeeper.get());
+      m_baton.reset();
+    } catch (const folly::FutureTimeout&) {
+      ++m_num_post_processing_delay_max_waits;
+    }
 
     if (m_latency_buffer_impl->occupancy() == 0) {
       continue;
@@ -315,11 +329,12 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule() {
     now = std::chrono::system_clock::now();
     milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_post_proc_time);
 
-    if (milliseconds.count() <= 1) {
+    if (milliseconds.count() <= m_post_processing_delay_min_wait) {
       continue;
     }
 
     last_post_proc_time = now;
+
     // Get the LB boundaries
     auto tail = m_latency_buffer_impl->back();
     newest_ts = tail->get_timestamp();

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -233,7 +233,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT& payload)
     ++m_num_payloads;
     ++m_sum_payloads;
     ++m_stats_packet_count;
-  }  
+  } else {
+    m_baton.post();
+  }
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
@@ -270,10 +272,6 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
         for (auto& i : transformed) {
           process_item(i);
         }   
-      }
-
-      if (m_processing_delay_ticks != 0) {
-        m_baton.post();
       }
     } else {
       ++m_rawq_timeout_count;
@@ -346,29 +344,7 @@ template<class RDT, class RHT, class LBT, class RPT, class IDT>
 void
 DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::consume_payload(RDT&& payload)
 {
- //m_rawq_timeout_count = 0;
- //m_num_payloads = 0;
- //m_sum_payloads = 0;
- //m_stats_packet_count = 0;
-  m_raw_processor_impl->preprocess_item(&payload);
-  if (m_request_handler_supports_cutoff_timestamp) {
-    int64_t diff1 = payload.get_timestamp() - m_request_handler_impl->get_cutoff_timestamp();
-    if (diff1 <= 0) {
-      //m_request_handler_impl->increment_tardy_tp_count();
-      ers::warning(DataPacketArrivedTooLate(ERS_HERE, m_run_number, payload.get_timestamp(),
-                                            m_request_handler_impl->get_cutoff_timestamp(), diff1,
-                                            (static_cast<double>(diff1)/62500.0)));
-    }
-  }
-  if (!m_latency_buffer_impl->write(std::move(payload))) {
-    TLOG_DEBUG(TLVL_TAKE_NOTE) << "***ERROR: Latency buffer is full and data was overwritten!";
-    m_num_payloads_overwritten++;
-  }
-#warning RS FIXME: Post-processing delay feature is not implemented in callback consume!
-  m_raw_processor_impl->postprocess_item(m_latency_buffer_impl->back());
-  ++m_num_payloads;
-  ++m_sum_payloads;
-  ++m_stats_packet_count;
+  process_item(payload);
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -80,7 +80,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerModu
   m_raw_receiver_sleep_us = std::chrono::microseconds::zero();
   m_sourceid.id = mcfg->get_source_id();
   m_sourceid.subsystem = RDT::subsystem;
-  m_processing_delay_ticks = 1;//mcfg->get_module_configuration()->get_post_processing_delay_ticks();
+  m_processing_delay_ticks = mcfg->get_module_configuration()->get_post_processing_delay_ticks();
   
 
   // Configure implementations:
@@ -248,7 +248,7 @@ void
 DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
 {
 
-  TLOG() << "Consumer thread started...";
+  TLOG_DEBUG(TLVL_WORK_STEPS) << "Consumer thread started...";
   m_rawq_timeout_count = 0;
   m_num_payloads = 0;
   m_sum_payloads = 0;

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -1,5 +1,7 @@
 // Declarations for DataHandlingModel
 
+#include <folly/coro/BlockingWait.h>
+
 #include <typeinfo>
 
 namespace dunedaq {
@@ -17,7 +19,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerModu
         m_data_request_receiver = get_iom_receiver<dfmessages::DataRequest>(input->UID()) ;
       }
       else {
-	m_raw_data_receiver_connection_name = input->UID();
+        m_raw_data_receiver_connection_name = input->UID();
         // Parse for prefix
         std::string conn_name = input->UID(); 
         const char delim = '_';
@@ -78,7 +80,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerModu
   m_raw_receiver_sleep_us = std::chrono::microseconds::zero();
   m_sourceid.id = mcfg->get_source_id();
   m_sourceid.subsystem = RDT::subsystem;
-  m_processing_delay_ticks = mcfg->get_module_configuration()->get_post_processing_delay_ticks();
+  m_processing_delay_ticks = 1;//mcfg->get_module_configuration()->get_post_processing_delay_ticks();
   
 
   // Configure implementations:
@@ -109,8 +111,12 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::conf(const nlohmann::json& /*args*/)
 
   // Configure threads:
   m_consumer_thread.set_name("consumer", m_sourceid.id);
-  if (m_generate_timesync)
+  if (m_generate_timesync) {
     m_timesync_thread.set_name("timesync", m_sourceid.id);
+  }
+  if (m_processing_delay_ticks) {
+    m_delayed_postprocessing_thread.set_name("dpostproc", m_sourceid.id);
+  }  
 }
 
 
@@ -137,7 +143,12 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const nlohmann::json& args)
   if (!m_callback_mode) {
     m_consumer_thread.set_work(&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume, this);
   }
-  if (m_generate_timesync) m_timesync_thread.set_work(&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync, this);
+  if (m_generate_timesync) {
+    m_timesync_thread.set_work(&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync, this);
+  }
+  if (m_processing_delay_ticks) {
+    m_delayed_postprocessing_thread.set_work(&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_delayed_postprocessing, this);
+  }  
   // Register callback to receive and dispatch data requests
   m_data_request_receiver->add_callback(
     std::bind(&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::dispatch_requests, this, std::placeholders::_1));
@@ -163,6 +174,12 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::stop(const nlohmann::json& args)
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
+  if (m_processing_delay_ticks) {
+    m_baton.post();
+    while (!m_delayed_postprocessing_thread.get_readiness()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }  
+  }  
   TLOG_DEBUG(TLVL_WORK_STEPS) << "Flushing latency buffer with occupancy: " << m_latency_buffer_impl->occupancy();
   m_latency_buffer_impl->flush();
   m_raw_processor_impl->stop(args);
@@ -211,7 +228,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT& payload)
     //TLOG_DEBUG(TLVL_TAKE_NOTE) << "***ERROR: Latency buffer is full and data was overwritten!";
     m_num_payloads_overwritten++;
   }
-  if (m_processing_delay_ticks ==0) {
+  if (m_processing_delay_ticks == 0) {
     m_raw_processor_impl->postprocess_item(m_latency_buffer_impl->back());
     ++m_num_payloads;
     ++m_sum_payloads;
@@ -221,24 +238,21 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT& payload)
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
 void 
+DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_delayed_postprocessing()
+{
+  folly::coro::blockingWait(delayed_postprocessing());
+}
+
+template<class RDT, class RHT, class LBT, class RPT, class IDT>
+void 
 DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
 {
 
-  TLOG_DEBUG(TLVL_WORK_STEPS) << "Consumer thread started...";
+  TLOG() << "Consumer thread started...";
   m_rawq_timeout_count = 0;
   m_num_payloads = 0;
   m_sum_payloads = 0;
   m_stats_packet_count = 0;
-
-  // Variables for book-keeping of delayed post-processing
-  //timestamp_t oldest_ts=0;
-  timestamp_t newest_ts=0;
-  timestamp_t end_win_ts=0;
-  bool first_cycle = true;
-  auto last_post_proc_time = std::chrono::system_clock::now();
-  auto now = last_post_proc_time;
-  std::chrono::milliseconds milliseconds;
-  RDT processed_element;
 
   while (m_run_marker.load()) {
     // Try to acquire data
@@ -257,49 +271,75 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
           process_item(i);
         }   
       }
+
+      if (m_processing_delay_ticks != 0) {
+        m_baton.post();
+      }
     } else {
       ++m_rawq_timeout_count;
       // Protection against a zero sleep becoming a yield
       if ( m_raw_receiver_sleep_us != std::chrono::microseconds::zero())
         std::this_thread::sleep_for(m_raw_receiver_sleep_us);
     }
-    
-    // Add here a possible deferral of the post processing, to allow elements being reordered in the LB
-    // Basically, find data older than a certain timestamp and process all data since the last post-processed element up to that value
-    if (m_processing_delay_ticks !=0 && m_latency_buffer_impl->occupancy() > 0) {
-      now = std::chrono::system_clock::now();
-      milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_post_proc_time);
+  }
+  TLOG_DEBUG(TLVL_WORK_STEPS) << "Consumer thread joins... ";
+}
 
-      if (milliseconds.count() > 1) {
-        last_post_proc_time = now;
-  	// Get the LB boundaries
-	auto tail = m_latency_buffer_impl->back();
-        newest_ts = tail->get_timestamp();
-        
-        if (first_cycle) {
-	  auto head = m_latency_buffer_impl->front();
-          processed_element.set_timestamp(head->get_timestamp()); 
-          first_cycle = false;
-	  TLOG() << "***** First pass post processing *****" ;
-        }
-        
-	if (newest_ts - processed_element.get_timestamp() > m_processing_delay_ticks) {
-    	  end_win_ts = newest_ts - m_processing_delay_ticks; 
-	  auto start_iter=m_latency_buffer_impl->lower_bound(processed_element, false);
-	  processed_element.set_timestamp(end_win_ts);
-	  auto end_iter=m_latency_buffer_impl->lower_bound(processed_element, false);
+template<class RDT, class RHT, class LBT, class RPT, class IDT>
+folly::coro::Task<void>
+DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::delayed_postprocessing() {  
+  TLOG() << "Delayed postprocessing coroutine started...";
 
-	  for (auto it = start_iter; it!= end_iter; ++it) { 
-              m_raw_processor_impl->postprocess_item(&(*it));
-              ++m_num_payloads;
-              ++m_sum_payloads;
-              ++m_stats_packet_count;
-	  }
- 	 }
+  timestamp_t newest_ts = 0;
+  timestamp_t end_win_ts = 0;
+  bool first_cycle = true;
+  auto last_post_proc_time = std::chrono::system_clock::now();
+  auto now = last_post_proc_time;
+  std::chrono::milliseconds milliseconds;
+  RDT processed_element;
+
+  // Add here a possible deferral of the post processing, to allow elements being reordered in the LB
+  // Basically, find data older than a certain timestamp and process all data since the last post-processed element up to that value  
+  while (m_run_marker.load()) {
+    co_await m_baton;
+    m_baton.reset();
+
+    if (m_latency_buffer_impl->occupancy() == 0) {
+      continue;
+    }
+
+    now = std::chrono::system_clock::now();
+    milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_post_proc_time);
+
+    if (milliseconds.count() <= 1) {
+      continue;
+    }
+    last_post_proc_time = now;
+    // Get the LB boundaries
+    auto tail = m_latency_buffer_impl->back();
+    newest_ts = tail->get_timestamp();
+
+    if (first_cycle) {
+      auto head = m_latency_buffer_impl->front();
+      processed_element.set_timestamp(head->get_timestamp());
+      first_cycle = false;
+      TLOG() << "***** First pass post processing *****";
+    }
+
+    if (newest_ts - processed_element.get_timestamp() > m_processing_delay_ticks) {
+      end_win_ts = newest_ts - m_processing_delay_ticks;
+      auto start_iter = m_latency_buffer_impl->lower_bound(processed_element, false);
+      processed_element.set_timestamp(end_win_ts);
+      auto end_iter = m_latency_buffer_impl->lower_bound(processed_element, false);
+
+      for (auto it = start_iter; it != end_iter; ++it) {
+        m_raw_processor_impl->postprocess_item(&(*it));
+        ++m_num_payloads;
+        ++m_sum_payloads;
+        ++m_stats_packet_count;
       }
     }
   }
-  TLOG_DEBUG(TLVL_WORK_STEPS) << "Consumer thread joins... ";
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -115,7 +115,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::conf(const nlohmann::json& /*args*/)
     m_timesync_thread.set_name("timesync", m_sourceid.id);
   }
   if (m_processing_delay_ticks) {
-    m_delayed_postprocessing_thread.set_name("dpostproc", m_sourceid.id);
+    m_postprocess_scheduler_thread.set_name("pprocsched", m_sourceid.id);
   }  
 }
 
@@ -147,7 +147,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const nlohmann::json& args)
     m_timesync_thread.set_work(&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync, this);
   }
   if (m_processing_delay_ticks) {
-    m_delayed_postprocessing_thread.set_work(&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_delayed_postprocessing, this);
+    m_postprocess_scheduler_thread.set_work(&DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_postprocess_scheduler, this);
   }  
   // Register callback to receive and dispatch data requests
   m_data_request_receiver->add_callback(
@@ -175,8 +175,8 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::stop(const nlohmann::json& args)
     }
   }
   if (m_processing_delay_ticks) {
-    m_baton.post();
-    while (!m_delayed_postprocessing_thread.get_readiness()) {
+    m_baton.post(); // In case the coroutine is still waiting when the consumer has stopped
+    while (!m_postprocess_scheduler_thread.get_readiness()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }  
   }  
@@ -240,9 +240,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT& payload)
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
 void 
-DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_delayed_postprocessing()
+DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_postprocess_scheduler()
 {
-  folly::coro::blockingWait(delayed_postprocessing());
+  folly::coro::blockingWait(postprocess_schedule());
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
@@ -285,8 +285,8 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
 folly::coro::Task<void>
-DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::delayed_postprocessing() {  
-  TLOG() << "Delayed postprocessing coroutine started...";
+DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule() {  
+  TLOG_DEBUG(TLVL_WORK_STEPS) << "Postprocess schedule coroutine started...";
 
   timestamp_t newest_ts = 0;
   timestamp_t end_win_ts = 0;
@@ -296,7 +296,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::delayed_postprocessing() {
   std::chrono::milliseconds milliseconds;
   RDT processed_element;
 
-  // Add here a possible deferral of the post processing, to allow elements being reordered in the LB
+  // Deferral of the post processing, to allow elements being reordered in the LB
   // Basically, find data older than a certain timestamp and process all data since the last post-processed element up to that value  
   while (m_run_marker.load()) {
     co_await m_baton;
@@ -312,6 +312,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::delayed_postprocessing() {
     if (milliseconds.count() <= 1) {
       continue;
     }
+
     last_post_proc_time = now;
     // Get the LB boundaries
     auto tail = m_latency_buffer_impl->back();

--- a/schema/datahandlinglibs/opmon/datahandling_info.proto
+++ b/schema/datahandlinglibs/opmon/datahandling_info.proto
@@ -21,6 +21,7 @@ message DataHandlerInfo {
   uint64 sum_requests = 11; // Total number of received requests 
   uint64 num_requests = 12; // Incremental number of received requests 
   uint64 last_daq_timestamp = 21; // Most recent DAQ timestamp processed 
+  uint64 num_post_processing_delay_max_waits = 31; // Number of times post-processing was triggered due to max wait time elapsing before data arrival
 }
 
 message RequestHandlerInfo {


### PR DESCRIPTION
- A new thread `pprocsched` is introduced to run the postprocessing scheduler coroutine. It is only spawned when `post_processing_delay_ticks` is configured.
- Previously, delayed postprocessing was tightly coupled with data reception and executed in the consumer thread. This coupling also meant the feature was not supported in callback mode.

Related: [Postprocessing delay min and max wait conf params #229](https://github.com/DUNE-DAQ/appmodel/pull/229)

**Coroutine as a design choice**
- Coroutines bring an event-driven approach; instead of blocking a thread or polling, they suspend and are resumed exactly when the event occurs.
- With threads, we would need a condition variable, which is prone to spurious wakeups and adds extra locking logic.
- Coroutines are easier to read; waiting for an event doesn't require locks or mutexes.
- Coroutines have lower overhead than threads for suspension/resumption since there's no OS-level context switch.

One downside of coroutines in C++20 is that they require you to define your own types with specific signatures. However, since `datahandlinglibs` already depends on `Folly`, we can make use of its predefined coroutine utilities under `folly::coro`.

For those who are interested, below are simplified examples illustrating how delayed postprocessing works.
[Why delayed postprocessing?](https://github.com/user-attachments/assets/387d780c-4191-448b-8883-14f03405a082)
[How does delayed postprocessing work? (Case 1)](https://github.com/user-attachments/assets/a7049a53-db20-44d7-9605-9f71e1dcf639)
[How does delayed postprocessing work? (Case 2)](https://github.com/user-attachments/assets/9cb103a0-62b0-47ea-8614-9aad0aae5ec6)

**Test runs**
Runs below were performed on July 29th. No CPU spikes were observed, and no significant performance changes were detected. (In the last two runs, `pprocsched` was pinned.)
Note: `FutureTimekeepr` checks for  `post_processing_delay_max_wait`.
```
post_processing_delay_ticks = 312500
post_processing_delay_min_wait = 1
post_processing_delay_max_wait = 5
```

<img width="948" height="1027" alt="image" src="https://github.com/user-attachments/assets/fa3a07f6-3b11-4b14-bbe5-67ef3a49596e" />