### PR TITLE
Processor Metrics Message

### DIFF
--- a/schema/datahandlinglibs/opmon/datahandling_info.proto
+++ b/schema/datahandlinglibs/opmon/datahandling_info.proto
@@ -76,11 +76,11 @@ message TPGProcessorInfo {
 }
 
 message TPGProcessorReducedInfo {
-  int64 mean = 1; // across plane
-  int64 max = 2; 
-  int64 min = 3;
-  uint64 max_channel_id = 4;
-  uint64 min_channel_id = 5;
-  double standard_dev = 6;
+  float mean = 1; // across plane
+  int32 max = 2; 
+  int32 min = 3;
+  uint32 max_channel_id = 4;
+  uint32 min_channel_id = 5;
+  float standard_dev = 6;
 }
 

--- a/schema/datahandlinglibs/opmon/datahandling_info.proto
+++ b/schema/datahandlinglibs/opmon/datahandling_info.proto
@@ -75,3 +75,12 @@ message TPGProcessorInfo {
   int64 accum = 2; // Accum value of AVXFrugalPedestalSubtractProcessor
 }
 
+message TPGProcessorReducedInfo {
+  int64 mean = 1; // across plane
+  int64 max = 2; 
+  int64 min = 3;
+  uint64 max_channel_id = 4;
+  uint64 min_channel_id = 5;
+  double standard_dev = 6;
+}
+

--- a/schema/datahandlinglibs/opmon/datahandling_info.proto
+++ b/schema/datahandlinglibs/opmon/datahandling_info.proto
@@ -70,3 +70,8 @@ message TPChannelInfo {
   uint64 number_of_tps = 2; // Numer of hits, i.e. TPs
 }
 
+message TPGProcessorInfo {
+  int64 pedestal = 1; // Pedestal value of AVXFrugalPedestalSubtractProcessor
+  int64 accum = 2; // Accum value of AVXFrugalPedestalSubtractProcessor
+}
+

--- a/schema/datahandlinglibs/opmon/datahandling_info.proto
+++ b/schema/datahandlinglibs/opmon/datahandling_info.proto
@@ -76,7 +76,7 @@ message TPGProcessorInfo {
 }
 
 message TPGProcessorReducedInfo {
-  float mean = 1; // across plane
+  float average = 1; // across plane
   int32 max = 2; 
   int32 min = 3;
   uint32 max_channel_id = 4;


### PR DESCRIPTION
### Summary of Changes in datahandlinglibs
https://github.com/DUNE-DAQ/tpglibs/pull/27
https://github.com/DUNE-DAQ/fdreadoutlibs/pull/272

Defined new messages accompanying work in processor metric monitoring.

#### Key Changes:
1. New Opmon Message Definitions
Added two new messages in` datahandling_info.proto`:
##### TPGProcessorInfo - For publishing individual processor metrics per channel:
- pedestal (int64) - Pedestal value from AVXFrugalPedestalSubtractProcessor
- accum (int64) - Accumulation value from AVXFrugalPedestalSubtractProcessor
##### TPGProcessorReducedInfo - For publishing aggregated metrics across detector planes:
- mean (int64) - Mean value across the plane
- max (int64) - Maximum value across the plane
- min (int64) - Minimum value across the plane
- max_channel_id (uint64) - Channel ID with maximum value
- min_channel_id (uint64) - Channel ID with minimum value
- standard_dev (double) - Standard deviation across the plane
