### PR TITLE
Johnfreeman/merge patch branches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(datahandlinglibs VERSION 3.1.6)
+project(datahandlinglibs VERSION 3.1.7)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -258,6 +258,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT&& payload)
   if (!m_latency_buffer_impl->write(std::move(payload))) {
     //TLOG_DEBUG(TLVL_TAKE_NOTE) << "***ERROR: Latency buffer insert failed! (Payload timestamp=" << payload.get_timestamp() << ")";
     m_num_lb_insert_failures++;
+    return;
   }
   if (m_processing_delay_ticks == 0) {
     m_raw_processor_impl->postprocess_item(m_latency_buffer_impl->back());


### PR DESCRIPTION
`johnfreeman/merge_patch_branches` is a branch which was forked off from `develop` and proceeded to have `patch/fddaq-v5.4.x` merged in; as such, this PR is intended to de-facto bring in code changes from `patch/fddaq-v5.4.x`. A successful test build was performed earlier today using all available `johnfreeman/merge_patch_branches` across repos (`MRGFD_DEV_250908_A9`, https://github.com/DUNE-DAQ/daq-release/actions/runs/17558744520) and integration tests were fully successful (https://github.com/DUNE-DAQ/daq-release/actions/runs/17561050175). 