### PR TITLE
Updated DataHandlingModel to set the SourceID of the current DAQModule in TimeSync messages

### DIFF
--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -95,7 +95,6 @@ public:
     , m_latency_buffer_impl(nullptr)
     , m_raw_processor_impl(nullptr)
   {
-    m_pid_of_current_process = getpid();
   }
 
   virtual ~DataHandlingModel() = default;
@@ -225,7 +224,6 @@ protected:
   std::shared_ptr<timesync_sender_ct> m_timesync_sender;
   utilities::ReusableThread m_timesync_thread;
   std::string m_timesync_connection_name;
-  uint32_t m_pid_of_current_process;
 
   // POSTPROCESS SCHEDULER
   utilities::ReusableThread m_postprocess_scheduler_thread;

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -397,10 +397,10 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync()
         prev_timestamp = timesyncmsg.daq_time;
         timesyncmsg.run_number = m_run_number;
         timesyncmsg.sequence_number = ++msg_seqno;
-        timesyncmsg.source_pid = m_pid_of_current_process;
+        timesyncmsg.source_id = m_sourceid;
         TLOG_DEBUG(TLVL_TIME_SYNCS) << "New timesync: daq=" << timesyncmsg.daq_time
           << " wall=" << timesyncmsg.system_time << " run=" << timesyncmsg.run_number
-          << " seqno=" << timesyncmsg.sequence_number << " pid=" << timesyncmsg.source_pid;
+          << " seqno=" << timesyncmsg.sequence_number << " source_id=" << timesyncmsg.source_id;
         try {
             dfmessages::TimeSync timesyncmsg_copy(timesyncmsg);
           m_timesync_sender->send(std::move(timesyncmsg_copy), std::chrono::milliseconds(500));

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -397,7 +397,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync()
         prev_timestamp = timesyncmsg.daq_time;
         timesyncmsg.run_number = m_run_number;
         timesyncmsg.sequence_number = ++msg_seqno;
-        timesyncmsg.source_id = m_sourceid;
+        timesyncmsg.source_id = m_sourceid.id;
         TLOG_DEBUG(TLVL_TIME_SYNCS) << "New timesync: daq=" << timesyncmsg.daq_time
           << " wall=" << timesyncmsg.system_time << " run=" << timesyncmsg.run_number
           << " seqno=" << timesyncmsg.sequence_number << " source_id=" << timesyncmsg.source_id;


### PR DESCRIPTION
## Description

These changes are part of a set of changes that are described in DUNE-DAQ/daq-deliverables#188.  Overall, the goal is to eliminate the use of Linux process IDs in identifying the source of TimeSync messages (to avoid problems with their use in certain environments) and use DAQ SourceID information instead.

Please see the `daq-deliverables` Issue for more details, including the full set of repositories that have correlated changes.

## Testing Suggestions

Please see DUNE-DAQ/daq-deliverables#188.
