### PR TITLE
Changes needed for exact window matching in DefaultRequestHandlerModel

### DIFF
--- a/include/datahandlinglibs/models/detail/DefaultRequestHandlerModel.hxx
+++ b/include/datahandlinglibs/models/detail/DefaultRequestHandlerModel.hxx
@@ -463,8 +463,10 @@ DefaultRequestHandlerModel<RDT, LBT>::get_fragment_pieces(uint64_t start_win_ts,
   }
   else {
     RDT request_element = RDT();
-    request_element.set_timestamp(start_win_ts-(request_element.get_num_frames() * RDT::expected_tick_difference));
-    //request_element.set_timestamp(start_win_ts);
+    auto start_timestamp = start_win_ts - (request_element.get_num_frames() * RDT::expected_tick_difference);
+    if (start_timestamp < last_ts)
+      start_timestamp = last_ts;
+    request_element.set_timestamp(start_timestamp);
 
     auto start_iter = m_error_registry->has_error("MISSING_FRAMES")
                       ? m_latency_buffer->lower_bound(request_element, true)
@@ -490,7 +492,7 @@ DefaultRequestHandlerModel<RDT, LBT>::get_fragment_pieces(uint64_t start_win_ts,
 
       RDT* element = &(*start_iter);
    
-      while (start_iter.good() && element->get_timestamp() < end_win_ts) {
+      while (start_iter.good() && element->get_timestamp() <= end_win_ts) {
         if ( element->get_timestamp() + element->get_num_frames() * RDT::expected_tick_difference <= start_win_ts) {
         //TLOG() << "skip processing for current element " << element->get_timestamp() << ", out of readout window.";
         } 

--- a/include/datahandlinglibs/models/detail/DefaultRequestHandlerModel.hxx
+++ b/include/datahandlinglibs/models/detail/DefaultRequestHandlerModel.hxx
@@ -480,7 +480,7 @@ DefaultRequestHandlerModel<RDT, LBT>::get_fragment_pieces(uint64_t start_win_ts,
     else {
       TLOG_DEBUG(TLVL_WORK_STEPS) << "Lower bound found " << start_iter->get_timestamp() << ", --> distance from window: " 
 	      << int64_t(start_win_ts) - int64_t(start_iter->get_timestamp()) ;  
-      if (end_win_ts > newest_ts) {
+      if (end_win_ts >= newest_ts) {
          rres.result_code = ResultCode::kPartial;
       }
       else if (start_win_ts < last_ts) {
@@ -494,7 +494,7 @@ DefaultRequestHandlerModel<RDT, LBT>::get_fragment_pieces(uint64_t start_win_ts,
 
       RDT* element = &(*start_iter);
    
-      while (start_iter.good() && element->get_timestamp() <= end_win_ts) {
+      while (start_iter.good() && element->get_timestamp() < end_win_ts) {
         if ( element->get_timestamp() + element->get_num_frames() * RDT::expected_tick_difference <= start_win_ts) {
         //TLOG() << "skip processing for current element " << element->get_timestamp() << ", out of readout window.";
         } 


### PR DESCRIPTION
Part of SNB demonstrator work:
https://github.com/DUNE-DAQ/daq-deliverables/issues/186

Current functional change is to clamp the timestamp used for the lower_bound call to the earliest timestamp in the buffer if there is not a full superchunk available before the window start time. Necessary for the SNB Transform test as the window start time will always be the start of the latency buffer.