### PR TITLE
Remove DefaultRequestHandlerModel obsolete member

### DIFF
--- a/include/datahandlinglibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/datahandlinglibs/models/DefaultRequestHandlerModel.hpp
@@ -241,7 +241,6 @@ protected:
   std::map<dfmessages::DataRequest, int> m_request_counter;
 
   // Requests
-  std::size_t m_max_requested_elements;
   std::mutex m_cv_mutex;
   std::condition_variable m_cv;
   std::atomic<bool> m_cleanup_requested = false;

--- a/include/datahandlinglibs/models/detail/DefaultRequestHandlerModel.hxx
+++ b/include/datahandlinglibs/models/detail/DefaultRequestHandlerModel.hxx
@@ -58,7 +58,7 @@ DefaultRequestHandlerModel<RDT, LBT>::conf(const appmodel::DataHandlerModule* co
   std::ostringstream oss;
   oss << "RequestHandler configured. " << std::fixed << std::setprecision(2)
       << "auto-pop limit: " << m_pop_limit_pct * 100.0f << "% "
-      << "auto-pop size: " << m_pop_size_pct * 100.0f << "% ";
+      << "auto-pop size: " << m_pop_size_pct * 100.0f << "%";
   TLOG_DEBUG(TLVL_WORK_STEPS) << oss.str();
 }
 

--- a/include/datahandlinglibs/models/detail/DefaultRequestHandlerModel.hxx
+++ b/include/datahandlinglibs/models/detail/DefaultRequestHandlerModel.hxx
@@ -49,7 +49,6 @@ DefaultRequestHandlerModel<RDT, LBT>::conf(const appmodel::DataHandlerModule* co
     ers::error(ConfigurationError(ERS_HERE, m_sourceid, "Auto-pop percentage out of range."));
   } else {
     m_pop_limit_size = m_pop_limit_pct * m_buffer_capacity;
-    m_max_requested_elements = m_pop_limit_size - m_pop_limit_size * m_pop_size_pct;
   }
 
   m_recording_thread.set_name("recording", m_sourceid.id);
@@ -59,8 +58,7 @@ DefaultRequestHandlerModel<RDT, LBT>::conf(const appmodel::DataHandlerModule* co
   std::ostringstream oss;
   oss << "RequestHandler configured. " << std::fixed << std::setprecision(2)
       << "auto-pop limit: " << m_pop_limit_pct * 100.0f << "% "
-      << "auto-pop size: " << m_pop_size_pct * 100.0f << "% "
-      << "max requested elements: " << m_max_requested_elements;
+      << "auto-pop size: " << m_pop_size_pct * 100.0f << "% ";
   TLOG_DEBUG(TLVL_WORK_STEPS) << oss.str();
 }
 


### PR DESCRIPTION
# Description

Obsolete member field `DefaultRequestHandlerModel::m_max_requested_elements` is removed.
Addresses issue #11  

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

