### PR TITLE
Rename cleanup member fields

### DIFF
--- a/include/datahandlinglibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/datahandlinglibs/models/DefaultRequestHandlerModel.hpp
@@ -100,9 +100,9 @@ public:
     , m_waiting_requests()
     , m_waiting_requests_lock()
     , m_error_registry(error_registry)
-    , m_pop_limit_pct(0.0f)
-    , m_pop_size_pct(0.0f)
-    , m_pop_limit_size(0)
+    , m_cleanup_min_occupancy_ratio(0.0f)
+    , m_cleanup_ratio(0.0f)
+    , m_cleanup_min_occupancy(0)
     , m_buffer_capacity(0)
     , m_pop_counter{ 0 }
     , m_pop_reqs(0)
@@ -265,9 +265,9 @@ protected:
 
   // Configuration
   bool m_configured;
-  float m_pop_limit_pct;     // buffer occupancy percentage to issue a pop request
-  float m_pop_size_pct;      // buffer percentage to pop
-  unsigned m_pop_limit_size; // pop_limit_pct * buffer_capacity
+  float m_cleanup_min_occupancy_ratio; // Minimum buffer occupancy ratio required to allow cleanup
+  float m_cleanup_ratio; // Buffer ratio to cleanup
+  unsigned m_cleanup_min_occupancy; // Minimum buffer occupancy required to allow cleanup
   size_t m_buffer_capacity;
   daqdataformats::SourceID m_sourceid;
   uint16_t m_detid;

--- a/include/datahandlinglibs/models/detail/DefaultRequestHandlerModel.hxx
+++ b/include/datahandlinglibs/models/detail/DefaultRequestHandlerModel.hxx
@@ -12,8 +12,8 @@ DefaultRequestHandlerModel<RDT, LBT>::conf(const appmodel::DataHandlerModule* co
   m_sourceid.id = conf->get_source_id();
   m_sourceid.subsystem = RDT::subsystem;
   m_detid = conf->get_detector_id();
-  m_pop_limit_pct = reqh_conf->get_pop_limit_pct();
-  m_pop_size_pct = reqh_conf->get_pop_size_pct();
+  m_cleanup_min_occupancy_ratio = reqh_conf->get_cleanup_min_occupancy_ratio();
+  m_cleanup_ratio = reqh_conf->get_cleanup_ratio();
 
   m_buffer_capacity = conf->get_module_configuration()->get_latency_buffer()->get_size();
   m_num_request_handling_threads = reqh_conf->get_handler_threads();
@@ -45,10 +45,10 @@ DefaultRequestHandlerModel<RDT, LBT>::conf(const appmodel::DataHandlerModule* co
   m_warn_about_empty_buffer = reqh_conf->get_warn_on_empty_buffer();
   m_periodic_data_transmission_ms = reqh_conf->get_periodic_data_transmission_ms();
   
-  if (m_pop_limit_pct < 0.0f || m_pop_limit_pct > 1.0f || m_pop_size_pct < 0.0f || m_pop_size_pct > 1.0f) {
-    ers::error(ConfigurationError(ERS_HERE, m_sourceid, "Auto-pop percentage out of range."));
+  if (m_cleanup_min_occupancy_ratio < 0.0f || m_cleanup_min_occupancy_ratio > 1.0f || m_cleanup_ratio < 0.0f || m_cleanup_ratio > 1.0f) {
+    ers::error(ConfigurationError(ERS_HERE, m_sourceid, "Cleanup ratio out of range."));
   } else {
-    m_pop_limit_size = m_pop_limit_pct * m_buffer_capacity;
+    m_cleanup_min_occupancy = m_cleanup_min_occupancy_ratio * m_buffer_capacity;
   }
 
   m_recording_thread.set_name("recording", m_sourceid.id);
@@ -57,8 +57,8 @@ DefaultRequestHandlerModel<RDT, LBT>::conf(const appmodel::DataHandlerModule* co
 
   std::ostringstream oss;
   oss << "RequestHandler configured. " << std::fixed << std::setprecision(2)
-      << "auto-pop limit: " << m_pop_limit_pct * 100.0f << "% "
-      << "auto-pop size: " << m_pop_size_pct * 100.0f << "%";
+      << "Minimum buffer occupancy ratio required to allow cleanup: " << m_cleanup_min_occupancy_ratio * 100.0f << "% "
+      << "Buffer ratio to cleanup: " << m_cleanup_ratio * 100.0f << "%";
   TLOG_DEBUG(TLVL_WORK_STEPS) << oss.str();
 }
 
@@ -213,7 +213,7 @@ void
 DefaultRequestHandlerModel<RDT, LBT>::cleanup_check()
 {
   std::unique_lock<std::mutex> lock(m_cv_mutex);
-  if (m_latency_buffer->occupancy() > m_pop_limit_size && !m_cleanup_requested.exchange(true)) {
+  if (m_latency_buffer->occupancy() > m_cleanup_min_occupancy && !m_cleanup_requested.exchange(true)) {
     m_cv.wait(lock, [&] { return m_requests_running == 0; });
     cleanup();
     m_cleanup_requested = false;
@@ -370,9 +370,9 @@ void
 DefaultRequestHandlerModel<RDT, LBT>::cleanup()
 {
   auto size_guess = m_latency_buffer->occupancy();
-  if (size_guess > m_pop_limit_size) {
+  if (size_guess > m_cleanup_min_occupancy) {
     ++m_pop_reqs;
-    unsigned to_pop = m_pop_size_pct * m_latency_buffer->occupancy();
+    unsigned to_pop = m_cleanup_ratio * m_latency_buffer->occupancy();
 
     unsigned popped = 0;
     for (size_t i = 0; i < to_pop; ++i) {


### PR DESCRIPTION
# Description

In `DefaultRequestHandlerModel`:
`m_pop_limit_pct` is renamed as `m_cleanup_min_occupancy_ratio`.
`m_pop_size_pct` is renamed as `m_cleanup_ratio`.
`m_pop_limit_size` is renamed as `m_cleanup_min_occupancy`.

**Let me know if you approve these name changes so I move on with the dependencies.**

Obvious dependencies: `appmodel` `daqsystemtest` `ehn1-daqconfigs `

Not-very-obvious dependencies:
- `lbrulibs` used in `python/lbrulibs/app_confgen.py` which looks very old and outdated.
- `dpdklibs` used in `python/dpdklibs/reader_confgen.py` which looks very old and outdated.
- `dfmodules` used in `test/config/hdf5write_test_hwmap.data.xml` which looks current.
- `dunedaq_conf_reader` used in `src/dunedaq_conf_reader/test/test-config.data.xml` and `src/dunedaq_conf_reader/test/test-config.data.json` which look current. 

So, `dfmodules` and `dunedaq_conf_reader` are also dependencies; `lbrulibs` and `dpdklibs`are not. **Let me know if you disagree.**

Addresses issue #10 

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas

