### PR TITLE
Skip delayed postprocessing of out-of-order data

### DIFF
--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -206,6 +206,12 @@ protected:
         end_win_ts = std::min(end_win_ts, newest_ts + 1); // Cap to prevent end_win_ts from becoming unnecessarily large 
       } else {
         m_consecutive_timeouts = 0;
+
+        if (m_processed_up_to.get_timestamp() >= newest_ts + 1) {
+          TLOG_DEBUG(TLVL_WORK_STEPS) << "Nothing to postprocess (data arrived too late, will be ignored)";
+          return 0;
+        }
+
         auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_post_proc_time);
 
         if (milliseconds.count() > m_post_processing_delay_min_wait) {

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -231,6 +231,18 @@ protected:
       m_processed_up_to.set_timestamp(end_win_ts);
       auto end_iter = m_latency_buffer_impl.lower_bound(m_processed_up_to, false);
 
+      // This likely happens when RDT uses a composite key
+      // The current algorithm does not support composite keys
+      // Our search item `m_processed_up_to` will have its other keys set to their defaults
+      // E.g., for TriggerPrimitive, channel = INVALID_TP_CHANNEL
+      // Even if an entry with the same ts exists in the buffer, its channel will be a valid value,
+      // so `lower_bound` will not be able to find it
+      // We should verify that this is the only scenario in which we end up here
+      if (!start_iter.good()) { 
+        TLOG_DEBUG(TLVL_WORK_STEPS) << "Nothing to postprocess (!start_iter.good())";
+        return 0;
+      }
+
       if (start_iter == end_iter) {
         TLOG_DEBUG(TLVL_WORK_STEPS) << "Nothing to postprocess (start_iter == end_iter)";
         return 0;
@@ -238,6 +250,12 @@ protected:
 
       int processed = 0;
       for (auto it = start_iter; it != end_iter; ++it) {
+        // Just to be completely safe
+        // We should understand why we end up here
+        if (!it.good()) { 
+          TLOG_DEBUG(TLVL_WORK_STEPS) << "Invalid iterator in postprocessing loop";
+          return 0;
+        }        
         m_raw_processor_impl.postprocess_item(&(*it));
         ++processed;
       }

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -235,7 +235,7 @@ protected:
       // The current algorithm does not support composite keys
       // Our search item `m_processed_up_to` will have its other keys set to their defaults
       // E.g., for TriggerPrimitive, channel = INVALID_TP_CHANNEL
-      // Even if an entry with the same ts exists in the buffer, its channel will be a valid value,
+      // Even if an entry with the same ts exists in the buffer, its channel will be a valid (smaller) value,
       // so `lower_bound` will not be able to find it
       // We should verify that this is the only scenario in which we end up here
       if (!start_iter.good()) { 
@@ -254,7 +254,7 @@ protected:
         // We should understand why we end up here
         if (!it.good()) { 
           TLOG_DEBUG(TLVL_WORK_STEPS) << "Invalid iterator in postprocessing loop";
-          return 0;
+          break;
         }        
         m_raw_processor_impl.postprocess_item(&(*it));
         ++processed;

--- a/unittest/datahandlinglibs_DataHandlingModel_test.cxx
+++ b/unittest/datahandlinglibs_DataHandlingModel_test.cxx
@@ -128,4 +128,65 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
   BOOST_REQUIRE_EQUAL(processed_count, 5);
 }
 
+BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgorithm_data_arrives_after_fully_processed_with_timeout)
+{
+  std::atomic<bool> run_marker = true;
+
+  auto model =
+    unittest::MockDataHandlingModel<ReadoutType,
+                                    DefaultRequestHandlerModel<ReadoutType, SkipListLatencyBufferModel<ReadoutType>>,
+                                    SkipListLatencyBufferModel<ReadoutType>,
+                                    TaskRawDataProcessorModel<ReadoutType>>(run_marker);
+
+  auto buffer = std::make_shared<SkipListLatencyBufferModel<ReadoutType>>();
+
+  for (int i = 1; i < 3; i++) {
+    ReadoutType frame{};
+    frame.timestamp = i * 62500;
+    buffer->write(std::move(frame));
+  }
+
+  {
+    ReadoutType frame{};
+    frame.timestamp = 4 * 62500;
+    buffer->write(std::move(frame));  
+  }
+
+  constexpr bool post_processing_enabled = true;
+  auto error_registry = std::make_unique<FrameErrorRegistry>();
+
+  auto raw_processor =
+    std::make_shared<TaskRawDataProcessorModel<ReadoutType>>(error_registry, post_processing_enabled);
+
+  constexpr uint64_t delay_ticks = 1 * 62500; // NOLINT(build/unsigned)
+  constexpr uint64_t delay_min_wait = 1; // NOLINT(build/unsigned)
+  constexpr uint64_t delay_max_wait = 2; // NOLINT(build/unsigned)
+
+  typename decltype(model)::PostprocessScheduleAlgorithm sched_algo{
+    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait
+  };
+
+  bool timeout = true;
+  int processed_count = sched_algo.run(timeout);
+  // Buffer = {1, 2, 4} delay_ticks = 1
+  // 1st timeout => timeout_accumulated = 1 * 2 (delay_max_wait = 2)
+  // end_win_ts = 4 - 1 + 2 => postprocess until 5 {1, 2, 4}
+  BOOST_REQUIRE_EQUAL(processed_count, 3);
+
+  {
+    ReadoutType frame{};
+    frame.timestamp = 3 * 62500;
+    buffer->write(std::move(frame));  
+  }
+  // Buffer = {1, 2, 3, 4}
+
+  // To not trigger the "too fast" case
+  std::this_thread::sleep_for(std::chrono::milliseconds(delay_min_wait + 1));
+
+  timeout = false;
+  // m_processed_up_to.timestamp = newest_ts + 1 => nothing to postprocess (data arrived too late)  
+  processed_count += sched_algo.run(timeout);
+  BOOST_REQUIRE_EQUAL(processed_count, 3);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Description

This PR fixes the segfault we were observing during delayed postprocessing. The very likely root cause of the problem is explained below.
With every timeout we virtually age `end_win_ts` so that the data which have been sitting in the buffer eventually become eligible for processing. We cap this age with `tail + 1` so that it doesn't grow to an unnecessarily big number (there's no point of increasing it beyond `tail`). And `+ 1` is there to ensure that the last element also gets processed, because the processing loop only runs until `it != end_iter`. On the other hand, we always set the next elem to be processed as the `end_win_ts` (`m_processed_up_to.set_timestamp(end_win_ts)`).
The cap essentially means that process the whole buffer. After this, `m_processed_up_to = tail + 1`.
If the next processing is triggered by data arrival and that data is out-of-order (smaller than tail) we will attempt to find `tail + 1` in the buffer and we won't be able to find it. And when we try to dereference it, we get segfault.

A relevant unit test is added.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)

