### PR TITLE
removethe EmptyFragment warning as it is no longer used

### DIFF
--- a/include/datahandlinglibs/DataHandlingIssues.hpp
+++ b/include/datahandlinglibs/DataHandlingIssues.hpp
@@ -116,12 +116,6 @@ ERS_DECLARE_ISSUE(datahandlinglibs,
                   "SourceID[" << sourceid << "] Got request for SourceID: " << request_sourceid,
                   ((daqdataformats::SourceID)sourceid)((daqdataformats::SourceID)request_sourceid))
 
-
-ERS_DECLARE_ISSUE(datahandlinglibs,
-                  TrmWithEmptyFragment,
-                  "SourceID[" << sourceid << "] Trigger Matching result with empty fragment: " << trmdetails,
-                  ((daqdataformats::SourceID)sourceid)((std::string)trmdetails))
-
 ERS_DECLARE_ISSUE(datahandlinglibs,
                   RequestOnEmptyBuffer,
                   "SourceID[" << sourceid << "] Request on empty buffer: " << trmdetails,

--- a/include/datahandlinglibs/models/detail/EmptyFragmentRequestHandlerModel.hxx
+++ b/include/datahandlinglibs/models/detail/EmptyFragmentRequestHandlerModel.hxx
@@ -15,7 +15,6 @@ EmptyFragmentRequestHandlerModel<ReadoutType, LatencyBufferType>::issue_request(
   auto fragment = std::make_unique<daqdataformats::Fragment>(std::vector<std::pair<void*, size_t>>());
   fragment->set_header_fields(frag_header);
 
-  // ers::warning(dunedaq::datahandlinglibs::TrmWithEmptyFragment(ERS_HERE, "DLH is configured to send empty fragment"));
   TLOG_DEBUG(TLVL_WORK_STEPS) << "DLH is configured to send empty fragment";
 
   try { // Push to Fragment queue


### PR DESCRIPTION
# Description

See issue #90 for details.

Addresses issue #90.

Changes can be tested by running minimal_system_quick_test and ensuring this works.

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

