### PR TITLE
Emulator callbacks should be acquired during start instead of conf

### DIFF
--- a/include/datahandlinglibs/concepts/SourceEmulatorConcept.hpp
+++ b/include/datahandlinglibs/concepts/SourceEmulatorConcept.hpp
@@ -34,12 +34,15 @@ public:
   SourceEmulatorConcept(SourceEmulatorConcept&&) = delete; ///< SourceEmulatorConcept is not move-constructible
   SourceEmulatorConcept& operator=(SourceEmulatorConcept&&) = delete; ///< SourceEmulatorConcept is not move-assignable
 
-  virtual void set_sender(const appmodel::DataMoveCallbackConf* /*sink*/) = 0;
   virtual void conf(const confmodel::DetectorStream* conf, const appmodel::StreamEmulationParameters* emu_conf) = 0;
   virtual void start(const appfwk::DAQModule::CommandData_t& /*args*/) = 0;
   virtual void stop(const appfwk::DAQModule::CommandData_t& /*args*/) = 0;
   virtual void scrap(const appfwk::DAQModule::CommandData_t& /*args*/) = 0;
   virtual bool is_configured() = 0;
+  
+  void set_sink_config(const appmodel::DataMoveCallbackConf* sink_conf) { m_sink_conf = sink_conf; }
+  virtual void acquire_callback() = 0;
+  const appmodel::DataMoveCallbackConf* m_sink_conf;
 
 private:
 };

--- a/include/datahandlinglibs/detail/FakeCardReaderBase.hxx
+++ b/include/datahandlinglibs/detail/FakeCardReaderBase.hxx
@@ -65,7 +65,7 @@ FakeCardReaderBase::do_conf(const appfwk::DAQModule::CommandData_t& /*args*/)
         TLOG() << "Emulator for queue name " << cb->UID() << " was already configured";
         throw datahandlinglibs::GenericConfigurationError(ERS_HERE, "Emulator configured twice: " + cb->UID());
       }
-      m_source_emus[cb->UID()]->set_sender(cb);
+      m_source_emus[cb->UID()]->set_sink_config(cb);
       m_source_emus[cb->UID()]->conf(streams[cb->get_source_id()],
                                             cfg->get_configuration()->get_emulation_conf());
     }
@@ -103,6 +103,7 @@ FakeCardReaderBase::do_start(const appfwk::DAQModule::CommandData_t& args)
   m_run_marker.store(true);
 
   for (auto& [name, emu] : m_source_emus) {
+    emu->acquire_callback();
     emu->start(args);
   }
 

--- a/include/datahandlinglibs/models/SourceEmulatorModel.hpp
+++ b/include/datahandlinglibs/models/SourceEmulatorModel.hpp
@@ -87,7 +87,7 @@ public:
   {}
 
   //void init(const appfwk::DAQModule::CommandData_t& /*args*/) {}
-  void set_sender(const appmodel::DataMoveCallbackConf* conf);
+  void acquire_callback() override;
 
   void conf(const confmodel::DetectorStream* stream_conf, const appmodel::StreamEmulationParameters* emu_conf);
   void scrap(const appfwk::DAQModule::CommandData_t& /*args*/)

--- a/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
@@ -20,10 +20,10 @@ SourceEmulatorPatternGenerator::generate(int source_id, int size)
 
 template<class ReadoutType>
 void
-SourceEmulatorModel<ReadoutType>::set_sender(const appmodel::DataMoveCallbackConf* conf)
+SourceEmulatorModel<ReadoutType>::acquire_callback()
 {
   if (!m_sender_is_set) {
-    m_raw_data_callback = datahandlinglibs::DataMoveCallbackRegistry::get()->get_callback<ReadoutType>(conf);
+    m_raw_data_callback = datahandlinglibs::DataMoveCallbackRegistry::get()->get_callback<ReadoutType>(SourceEmulatorConcept::m_sink_conf);
     m_sender_is_set = true;
   } else {
     // ers::error();


### PR DESCRIPTION
Similar to reader modules (such as DPDKReaderModule, CRT reader modules), emulator callbacks should be acquired during start, not conf. Because the ones who register (such as DataHandlingModel, SocketWriterModule) register them during conf. We shouldn't try to acquire before they're registered.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)