### PR TITLE
Delayed postprocessing refactor with new monitoring variables

### DIFF
--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -137,7 +137,9 @@ protected:
   {
   public:
     struct PostprocessState {
+      // Where to start processing in the next iteration
       timestamp_t next_window_start_ts{ 0 };
+
       timestamp_t last_processed_ts{ 0 };
     };
 
@@ -154,7 +156,6 @@ protected:
       , m_post_processing_delay_min_wait{ post_processing_delay_min_wait }
       , m_post_processing_delay_max_wait{ post_processing_delay_max_wait }
       , m_first_cycle{ true }
-      , m_is_timeout{ false }
       , m_state{ state }
       , m_state_mutex{ state_mutex }
       , m_last_post_proc_time{ std::chrono::system_clock::now() }
@@ -165,9 +166,7 @@ protected:
     // High-level interface
     // Schedule deferred post-processing and notify timeout expiration to the processor
     int run(bool timeout) {
-      m_is_timeout = timeout;
-
-      int processed = this->do_run();
+      int processed = this->do_run(timeout);
 
       // if (timeout) {
       //   timestamp_t timeout_accumulated = m_consecutive_timeouts * m_max_wait_in_ticks;
@@ -179,7 +178,7 @@ protected:
 
     // Deferral of the post processing, to allow elements being reordered in the LB
     // Basically, find data older than a certain timestamp and process all data since the last post-processed element up to that value
-    int do_run()
+    int do_run(bool timeout)
     {
       if (m_latency_buffer_impl.occupancy() == 0) {
         TLOG() << "Nothing to postprocess (empty buffer)";
@@ -187,16 +186,25 @@ protected:
       }
 
       if (m_first_cycle) { // first data arrival
-        handle_first_cycle();
+        auto head = m_latency_buffer_impl.front();
+        auto oldest_ts = head->get_timestamp();
+
+        set_postprocessing_state(oldest_ts, 0);
+
+        m_first_cycle = false;
+        TLOG() << "***** First pass post processing *****";
         return 0;
       }
 
-      // Get the LB boundaries
       auto tail = m_latency_buffer_impl.back();
       const auto newest_ts = tail->get_timestamp();
 
-      const auto next_window_start_ts = get_next_window_start_ts();
+      auto [next_window_start_ts, last_processed_ts] = get_postprocessing_state();
       
+      // This happens if the entire buffer was already processed in a previous iteration
+      // and no newer data arrived since then.
+      // e.g. Buffer: {1, 3}. We already processed {1, 3}. Now {2} arrives.
+      //      We notice this because next window start is {4} (last processed + 1) and 4 > 3.   
       if (next_window_start_ts > newest_ts) {
         TLOG() << "Postprocessing window is already closed";
         return 0;
@@ -204,15 +212,14 @@ protected:
 
       auto now = std::chrono::system_clock::now();
 
-      if (!m_is_timeout) { // data arrival
-        auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_post_proc_time);
-        if (milliseconds.count() <= m_post_processing_delay_min_wait) {
+      if (!timeout) { // data arrival
+        if (now - m_last_post_proc_time <= std::chrono::milliseconds(m_post_processing_delay_min_wait)) {
           TLOG_DEBUG(TLVL_WORK_STEPS) << "Not enough time passed since last postprocessing";
           return 0;
         }        
       }
 
-      RDT next_window_start{};
+      RDT next_window_start{}; // braces are essential for value initialization
       next_window_start.set_timestamp(next_window_start_ts);
       auto start_iter = m_latency_buffer_impl.lower_bound(next_window_start, false);
 
@@ -224,38 +231,43 @@ protected:
       // so `lower_bound` will not be able to find it
       // We should verify that this is the only scenario in which we end up here
       if (!start_iter.good()) {
-        TLOG() << "Nothing to postprocess (!start_iter.good())";
+        TLOG() << "Postprocessing next window start cannot be found in the buffer (known issue with composite keys)";
         return 0;
       }
 
       size_t processed = 0;
-      auto last_processed_ts = get_last_processed_ts();
       
-      auto window_end_ts = newest_ts + 1; // entire buffer
+      timestamp_t window_end_ts = 0;
+      bool processed_entire_buffer = true;
       auto it = start_iter;
 
       for (; it.good(); ++it) {
         const auto ts = it->get_timestamp();
 
-        update_timeout_count(ts);
+        if (timeout) {
+          update_timeout_count(ts);
+        }
 
-        const auto effective_ts = get_effective_ts(ts);
-
-        if (is_not_ready_for_processing(newest_ts, effective_ts)) {
+        if (is_too_early_to_process(ts, newest_ts)) {
           window_end_ts = ts;
+          processed_entire_buffer = false;
           break;
         }
 
         postprocess_item(&(*it), processed, last_processed_ts);
       }
-
-      set_postprocessing_state(window_end_ts, last_processed_ts);
-
-      if (window_end_ts == newest_ts + 1) {
-        TLOG() << "Entire buffer was postprocessed";
-      } else {
-        update_remaining_timeout_counts(it);
+      
+      if (timeout) {
+        if (processed_entire_buffer) {
+          TLOG() << "Entire buffer is postprocessed";
+          window_end_ts = last_processed_ts + 1; // The loop didn't break and `window_end_ts` wasn't set.
+        } else {
+          update_remaining_timeout_counts(it);
+        }
       }
+      
+      // Make `window_end_ts` the next window start.
+      set_postprocessing_state(window_end_ts, last_processed_ts);
 
       m_last_post_proc_time = now;
 
@@ -263,16 +275,10 @@ protected:
     }
 
   private:
-    timestamp_t get_next_window_start_ts()
+    PostprocessState get_postprocessing_state()
     {
       std::lock_guard<std::mutex> lock(m_state_mutex);
-      return m_state.next_window_start_ts;
-    }
-
-    timestamp_t get_last_processed_ts()
-    {
-      std::lock_guard<std::mutex> lock(m_state_mutex);
-      return m_state.last_processed_ts;
+      return m_state;
     }
 
     void set_postprocessing_state(timestamp_t next_window_start_ts, timestamp_t last_processed_ts)
@@ -280,16 +286,6 @@ protected:
       std::lock_guard<std::mutex> lock(m_state_mutex);
       m_state.next_window_start_ts = next_window_start_ts;
       m_state.last_processed_ts = last_processed_ts;
-    }
-
-    void handle_first_cycle() {
-      auto head = m_latency_buffer_impl.front();
-      auto oldest_ts = head->get_timestamp();
-      
-      set_postprocessing_state(oldest_ts, 0);
-
-      m_first_cycle = false;
-      TLOG() << "***** First pass post processing *****";
     }
 
     void postprocess_item(const ReadoutType* item, size_t& processed, timestamp_t& last_processed_ts)
@@ -304,15 +300,12 @@ protected:
 
     void update_timeout_count(timestamp_t ts)
     {
-      auto& timeout_count = m_timeout_count_map[ts];
-      if (m_is_timeout) {
-        ++timeout_count;
-      }
+      ++m_timeout_count_map[ts];
     }    
 
     void update_remaining_timeout_counts(auto it)
     {
-      if (it.good()) { 
+      if (it.good()) {
         ++it; // skip 1 because its entry should already be updated in the end window finding loop
       } else [[unlikely]] {
         TLOG() << "Unexpected delayed postprocessing state: iterator invalid before updating remaining timeouts";
@@ -321,32 +314,26 @@ protected:
       for (; it.good(); ++it) {
         update_timeout_count(it->get_timestamp());
       }
-    }    
-
-    int64_t get_effective_ts(timestamp_t ts) const {
-      const auto ts_signed = static_cast<int64_t>(ts);
-      const auto it = m_timeout_count_map.find(ts);
-
-      if (it == m_timeout_count_map.end()) [[unlikely]] {
-        TLOG() << "Unexpected delayed postprocessing state: missing timeout count for " << ts;
-        return ts_signed;
-      }
-
-      const auto timeout_count = it->second;      
-
-      const int64_t virtual_age =
-        static_cast<int64_t>(timeout_count) * static_cast<int64_t>(m_max_wait_in_ticks);
-
-      return ts_signed - virtual_age;
     }
 
-    bool is_not_ready_for_processing(timestamp_t newest_ts, int64_t effective_ts) const
+    size_t get_timeout_count(timestamp_t ts) const
     {
-      const auto newest_ts_signed = static_cast<int64_t>(newest_ts);
-      const auto delay_ticks_signed = static_cast<int64_t>(m_processing_delay_ticks);
-
-      return newest_ts_signed - effective_ts <= delay_ticks_signed;
+      auto it = m_timeout_count_map.find(ts);
+      return (it != m_timeout_count_map.end()) ? it->second : 0;
     }    
+
+    bool is_too_early_to_process(timestamp_t ts, timestamp_t newest_ts) const
+    {
+      // An item can be processed if it is "old enough" relative to the newest timestamp. 
+      // The age difference must be bigger than the delay ticks we configure; otherwise, it is too early to process.
+      const auto age_diff = newest_ts - ts;
+
+      // Timeouts artificially make items older; that is why, on top of the (real) age difference,
+      // we add the virtual age of the item.
+      const auto virtual_age = get_timeout_count(ts) * m_max_wait_in_ticks;
+
+      return age_diff + virtual_age <= m_processing_delay_ticks;
+    }  
 
     LatencyBufferType& m_latency_buffer_impl;
     RawDataProcessorType& m_raw_processor_impl;
@@ -355,9 +342,11 @@ protected:
     const uint64_t m_post_processing_delay_max_wait; // NOLINT(build/unsigned)
     const timestamp_t m_max_wait_in_ticks;
     bool m_first_cycle;
-    bool m_is_timeout;
     PostprocessState& m_state;
     std::mutex& m_state_mutex;
+    // Keeps track of timeout counts of not-yet-processed items.
+    // This is required because not every item waits in the buffer the same amount of time.
+    // This number will be used to decide if an item can be processed.
     std::map<timestamp_t, std::size_t> m_timeout_count_map;
     std::chrono::time_point<std::chrono::system_clock> m_last_post_proc_time;    
   };

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -138,9 +138,9 @@ protected:
   public:
     struct PostprocessState {
       // Where to start processing in the next iteration
-      timestamp_t next_window_start_ts{ 0 };
+      std::atomic<timestamp_t> next_window_start_ts{ 0 };
 
-      timestamp_t last_processed_ts{ 0 };
+      std::atomic<timestamp_t> last_processed_ts{ 0 };
     };
 
     PostprocessScheduleAlgorithm(LatencyBufferType& latency_buffer_impl,
@@ -148,18 +148,16 @@ protected:
                                  uint64_t processing_delay_ticks, // NOLINT(build/unsigned)
                                  uint64_t post_processing_delay_min_wait, // NOLINT(build/unsigned)
                                  uint64_t post_processing_delay_max_wait, // NOLINT(build/unsigned)
-                                 PostprocessState& state,
-                                 std::mutex& state_mutex) 
+                                 PostprocessState& state) 
       : m_latency_buffer_impl{ latency_buffer_impl }
       , m_raw_processor_impl{ raw_processor_impl }
       , m_processing_delay_ticks{ processing_delay_ticks }
       , m_post_processing_delay_min_wait{ post_processing_delay_min_wait }
       , m_post_processing_delay_max_wait{ post_processing_delay_max_wait }
+      , m_max_wait_in_ticks{ post_processing_delay_max_wait * 62500 } // FIXME: hardcoded clock frequency
       , m_first_cycle{ true }
       , m_state{ state }
-      , m_state_mutex{ state_mutex }
       , m_last_post_proc_time{ std::chrono::system_clock::now() }
-      , m_max_wait_in_ticks{ post_processing_delay_max_wait * 62500 } // FIXME: hardcoded clock frequency
     {
     }   
 
@@ -181,7 +179,7 @@ protected:
     int do_run(bool timeout)
     {
       if (m_latency_buffer_impl.occupancy() == 0) {
-        TLOG() << "Nothing to postprocess (empty buffer)";
+        TLOG_DEBUG(TLVL_WORK_STEPS) << "Nothing to postprocess (empty buffer)";
         return 0;
       }
 
@@ -199,14 +197,14 @@ protected:
       auto tail = m_latency_buffer_impl.back();
       const auto newest_ts = tail->get_timestamp();
 
-      auto [next_window_start_ts, last_processed_ts] = get_postprocessing_state();
+      const auto next_window_start_ts = m_state.next_window_start_ts.load(std::memory_order_relaxed);
       
       // This happens if the entire buffer was already processed in a previous iteration
       // and no newer data arrived since then.
       // e.g. Buffer: {1, 3}. We already processed {1, 3}. Now {2} arrives.
       //      We notice this because next window start is {4} (last processed + 1) and 4 > 3.   
       if (next_window_start_ts > newest_ts) {
-        TLOG() << "Postprocessing window is already closed";
+        TLOG_DEBUG(TLVL_WORK_STEPS) << "Postprocessing window is already closed";
         return 0;
       }
 
@@ -231,7 +229,7 @@ protected:
       // so `lower_bound` will not be able to find it
       // We should verify that this is the only scenario in which we end up here
       if (!start_iter.good()) {
-        TLOG() << "Postprocessing next window start cannot be found in the buffer (known issue with composite keys)";
+        TLOG_DEBUG(TLVL_WORK_STEPS) << "Postprocessing next window start cannot be found in the buffer (known issue with composite keys)";
         return 0;
       }
 
@@ -239,6 +237,7 @@ protected:
       
       timestamp_t window_end_ts = 0;
       bool processed_entire_buffer = true;
+      auto last_processed_ts = m_state.last_processed_ts.load(std::memory_order_relaxed);
       auto it = start_iter;
 
       for (; it.good(); ++it) {
@@ -259,7 +258,7 @@ protected:
       
       if (timeout) {
         if (processed_entire_buffer) {
-          TLOG() << "Entire buffer is postprocessed";
+          TLOG_DEBUG(TLVL_WORK_STEPS) << "Entire buffer is postprocessed";
           window_end_ts = last_processed_ts + 1; // The loop didn't break and `window_end_ts` wasn't set.
         } else {
           update_remaining_timeout_counts(it);
@@ -275,17 +274,11 @@ protected:
     }
 
   private:
-    PostprocessState get_postprocessing_state()
-    {
-      std::lock_guard<std::mutex> lock(m_state_mutex);
-      return m_state;
-    }
 
     void set_postprocessing_state(timestamp_t next_window_start_ts, timestamp_t last_processed_ts)
     {
-      std::lock_guard<std::mutex> lock(m_state_mutex);
-      m_state.next_window_start_ts = next_window_start_ts;
-      m_state.last_processed_ts = last_processed_ts;
+      m_state.next_window_start_ts.store(next_window_start_ts, std::memory_order_relaxed);
+      m_state.last_processed_ts.store(last_processed_ts, std::memory_order_relaxed);
     }
 
     void postprocess_item(const ReadoutType* item, size_t& processed, timestamp_t& last_processed_ts)
@@ -308,7 +301,7 @@ protected:
       if (it.good()) {
         ++it; // skip 1 because its entry should already be updated in the end window finding loop
       } else [[unlikely]] {
-        TLOG() << "Unexpected delayed postprocessing state: iterator invalid before updating remaining timeouts";
+        TLOG_DEBUG(TLVL_WORK_STEPS) << "Unexpected delayed postprocessing state: iterator invalid before updating remaining timeouts";
       }
 
       for (; it.good(); ++it) {
@@ -343,7 +336,6 @@ protected:
     const timestamp_t m_max_wait_in_ticks;
     bool m_first_cycle;
     PostprocessState& m_state;
-    std::mutex& m_state_mutex;
     // Keeps track of timeout counts of not-yet-processed items.
     // This is required because not every item waits in the buffer the same amount of time.
     // This number will be used to decide if an item can be processed.
@@ -460,7 +452,6 @@ protected:
   folly::coro::Baton m_baton;
   std::unique_ptr<folly::Timekeeper> m_timekeeper;
   PostprocessScheduleAlgorithm::PostprocessState m_postprocess_state;
-  std::mutex m_postprocess_state_mutex;  
 
   // LATENCY BUFFER
   std::shared_ptr<LatencyBufferType> m_latency_buffer_impl;

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -154,7 +154,7 @@ protected:
       , m_post_processing_delay_min_wait{ post_processing_delay_min_wait }
       , m_post_processing_delay_max_wait{ post_processing_delay_max_wait }
       , m_first_cycle{ true }
-      , m_next_window_start{}
+      , m_is_timeout{ false }
       , m_state{ state }
       , m_state_mutex{ state_mutex }
       , m_last_post_proc_time{ std::chrono::system_clock::now() }
@@ -165,7 +165,9 @@ protected:
     // High-level interface
     // Schedule deferred post-processing and notify timeout expiration to the processor
     int run(bool timeout) {
-      int processed = this->do_run(timeout);
+      m_is_timeout = timeout;
+
+      int processed = this->do_run();
 
       // if (timeout) {
       //   timestamp_t timeout_accumulated = m_consecutive_timeouts * m_max_wait_in_ticks;
@@ -177,20 +179,18 @@ protected:
 
     // Deferral of the post processing, to allow elements being reordered in the LB
     // Basically, find data older than a certain timestamp and process all data since the last post-processed element up to that value
-    int do_run(bool timeout)
+    int do_run()
     {
       if (m_latency_buffer_impl.occupancy() == 0) {
         TLOG() << "Nothing to postprocess (empty buffer)";
         return 0;
       }
 
-      if (m_first_cycle) {
-        m_timeout_counts.push_back(0);
-
+      if (m_first_cycle) { // first data arrival
         auto head = m_latency_buffer_impl.front();
-
-        m_next_window_start.set_timestamp(head->get_timestamp());
-        set_postprocessing_state(m_next_window_start.get_timestamp(), 0);
+        auto oldest_ts = head->get_timestamp();
+        
+        set_postprocessing_state(oldest_ts, 0);
 
         m_first_cycle = false;
 
@@ -200,42 +200,32 @@ protected:
 
       // Get the LB boundaries
       auto tail = m_latency_buffer_impl.back();
-      auto newest_ts = tail->get_timestamp();
+      const auto newest_ts = tail->get_timestamp();
+
+      const auto next_window_start_ts = get_next_window_start_ts();
       
-      std::chrono::time_point<std::chrono::system_clock> now{ std::chrono::system_clock::now() };
+      if (next_window_start_ts >= newest_ts + 1) {
+        TLOG() << "Nothing to postprocess (all items are processed already)";
+        return 0;
+      }
 
-      if (timeout) {
-        if (m_next_window_start.get_timestamp() >= newest_ts + 1) {
-          TLOG() << "Nothing to postprocess (all items are processed already)";
-          return 0;
-        }
+      auto now = std::chrono::system_clock::now();
 
-        for (auto& count : m_timeout_counts) {
-          ++count;
-        }      
-      } else { // data arrival
-        if (m_next_window_start.get_timestamp() >= newest_ts + 1) {
-          TLOG() << "Nothing to postprocess (data arrived for a closed processing window, all items are processed already)";
-          return 0;
-        }
-                
-        m_timeout_counts.push_back(0);
-
+      if (!m_is_timeout) { // data arrival
         auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_post_proc_time);
         if (milliseconds.count() <= m_post_processing_delay_min_wait) {
-          TLOG() << "Not ready to postprocess (too fast)";
+          TLOG_DEBUG(TLVL_WORK_STEPS) << "Not ready to postprocess (too fast)";
           return 0;
         }        
       }
-            
-      timestamp_t ts_window_end = newest_ts + 1;
-      size_t timeout_idx = 0;
-      
-      auto start_iter = m_latency_buffer_impl.lower_bound(m_next_window_start, false);
+
+      RDT next_window_start{};
+      next_window_start.set_timestamp(next_window_start_ts);
+      auto start_iter = m_latency_buffer_impl.lower_bound(next_window_start, false);
 
       // This likely happens when RDT uses a composite key
       // The current algorithm does not support composite keys
-      // Our search item `m_next_window_start` will have its other keys set to their defaults
+      // Our search item `next_window_start` will have its other keys set to their defaults
       // E.g., for TriggerPrimitive, channel = INVALID_TP_CHANNEL
       // Even if an entry with the same ts exists in the buffer, its channel will be a valid (smaller) value,
       // so `lower_bound` will not be able to find it
@@ -245,73 +235,52 @@ protected:
         return 0;
       }
 
-      auto it = start_iter;
-      while (true) {
-        // Just to be completely safe
-        // We should understand why we end up here
-        if (!it.good()) {
-          TLOG() << "Invalid iterator during end window find loop";
-          return 0;
-        }
-
-        auto ts = it->get_timestamp();
-        auto effective_ts = get_effective_ts(ts, timeout_idx);
-        int64_t newest_ts_signed = static_cast<int64_t>(newest_ts);
-        int64_t delay_ticks_signed = static_cast<int64_t>(m_processing_delay_ticks);
-
-        if (newest_ts_signed - effective_ts <= delay_ticks_signed) {
-          ts_window_end = ts;
-          break;
-        }
-
-        if (&(*it) == tail) {
-          break;
-        }
-        ++it;
-        ++timeout_idx;
-      }
-
-      if (ts_window_end == newest_ts + 1) {
-        TLOG() << "This will process everything";
-      }
-
-      RDT window_end = m_next_window_start;
-      window_end.set_timestamp(ts_window_end);
-      auto end_iter = m_latency_buffer_impl.lower_bound(window_end, false);
-
-      if (start_iter == end_iter) {
-        TLOG() << "Nothing to postprocess (start_iter == end_iter)";
-        return 0;
-      }
-
-      int processed = 0;
+      size_t processed = 0;
       auto last_processed_ts = get_last_processed_ts();
-      for (auto it = start_iter; it != end_iter; ++it) {
-        // Just to be completely safe
-        // We should understand why we end up here
-        if (!it.good()) {
-          TLOG() << "Invalid iterator in postprocessing loop";
+      
+      auto window_end_ts = newest_ts + 1; // entire buffer
+      auto it = start_iter;
+
+      for (; it.good(); ++it) {
+        const auto ts = it->get_timestamp();
+
+        update_timeout_count(ts);
+
+        const auto effective_ts = get_effective_ts(ts);
+
+        if (is_not_ready_for_processing(newest_ts, effective_ts)) {
+          window_end_ts = ts;
           break;
         }
-        m_raw_processor_impl.postprocess_item(&(*it));
-        last_processed_ts = it->get_timestamp();
-        ++processed;
+
+        postprocess_item(&(*it), processed, last_processed_ts);
       }
 
-      m_next_window_start.set_timestamp(ts_window_end);
-      set_postprocessing_state(ts_window_end, last_processed_ts);
+      if (window_end_ts == newest_ts + 1) {
+        if (it.good()) {
+          TLOG() << "Processing entire buffer";
+          postprocess_item(&(*it), processed, last_processed_ts);
+        } else {
+          TLOG() << "Unexpected delayed postprocessing state: iterator invalid when processing entire buffer";
+        }
+      } else {
+        update_remaining_timeout_counts(it);
+      }
+
+      set_postprocessing_state(window_end_ts, last_processed_ts);
 
       m_last_post_proc_time = now;
-
-      if (processed > 0) {
-        m_timeout_counts.erase(m_timeout_counts.begin(),
-                               m_timeout_counts.begin() + processed);
-      }
 
       return processed;
     }
 
   private:
+    timestamp_t get_next_window_start_ts()
+    {
+      std::lock_guard<std::mutex> lock(m_state_mutex);
+      return m_state.next_window_start_ts;
+    }
+
     timestamp_t get_last_processed_ts()
     {
       std::lock_guard<std::mutex> lock(m_state_mutex);
@@ -325,24 +294,65 @@ protected:
       m_state.last_processed_ts = last_processed_ts;
     }
 
-    int64_t get_effective_ts(timestamp_t ts, size_t timeout_idx) {
-      int64_t virtual_age = 
-        static_cast<int64_t>(m_timeout_counts[timeout_idx]) * static_cast<int64_t>(m_max_wait_in_ticks);
+    void postprocess_item(const ReadoutType* item, size_t& processed, timestamp_t& last_processed_ts)
+    {
+      m_raw_processor_impl.postprocess_item(item);
+
+      const auto ts = item->get_timestamp();
+      ++processed;
+      last_processed_ts = ts;
+      m_timeout_count_map.erase(ts);
+    }    
+
+    void update_timeout_count(timestamp_t ts)
+    {
+      auto& timeout_count = m_timeout_count_map[ts];
+      if (m_is_timeout) {
+        ++timeout_count;
+      }
+    }    
+
+    void update_remaining_timeout_counts(auto it)
+    {
+      if (it.good()) { 
+        ++it; // skip 1 because its entry should already be updated in the window finding loop
+      } else {
+        TLOG() << "Unexpected delayed postprocessing state: iterator invalid before updating remaining timeouts";
+      }
+
+      for (; it.good(); ++it) {
+        update_timeout_count(it->get_timestamp());
+      }
+    }    
+
+    int64_t get_effective_ts(timestamp_t ts) const {
+      const auto timeout_count = m_timeout_count_map.at(ts);
+
+      const int64_t virtual_age =
+        static_cast<int64_t>(timeout_count) * static_cast<int64_t>(m_max_wait_in_ticks);
 
       return static_cast<int64_t>(ts) - virtual_age;
     }
+
+    bool is_not_ready_for_processing(timestamp_t newest_ts, int64_t effective_ts) const
+    {
+      const auto newest_ts_signed = static_cast<int64_t>(newest_ts);
+      const auto delay_ticks_signed = static_cast<int64_t>(m_processing_delay_ticks);
+
+      return newest_ts_signed - effective_ts <= delay_ticks_signed;
+    }    
 
     LatencyBufferType& m_latency_buffer_impl;
     RawDataProcessorType& m_raw_processor_impl;
     const uint64_t m_processing_delay_ticks; // NOLINT(build/unsigned)
     const uint64_t m_post_processing_delay_min_wait; // NOLINT(build/unsigned)
     const uint64_t m_post_processing_delay_max_wait; // NOLINT(build/unsigned)
+    const timestamp_t m_max_wait_in_ticks;
     bool m_first_cycle;
-    RDT m_next_window_start;
+    bool m_is_timeout;
     PostprocessState& m_state;
     std::mutex& m_state_mutex;
-    std::vector<std::size_t> m_timeout_counts;
-    const timestamp_t m_max_wait_in_ticks;
+    std::map<timestamp_t, std::size_t> m_timeout_count_map;
     std::chrono::time_point<std::chrono::system_clock> m_last_post_proc_time;    
   };
 

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -146,15 +146,15 @@ protected:
     PostprocessScheduleAlgorithm(LatencyBufferType& latency_buffer_impl,
                                  RawDataProcessorType& raw_processor_impl,
                                  uint64_t processing_delay_ticks, // NOLINT(build/unsigned)
-                                 uint64_t post_processing_delay_min_wait, // NOLINT(build/unsigned)
-                                 uint64_t post_processing_delay_max_wait, // NOLINT(build/unsigned)
+                                 uint64_t post_processing_delay_min_wait_ms, // NOLINT(build/unsigned)
+                                 uint64_t post_processing_delay_max_wait_ms, // NOLINT(build/unsigned)
                                  PostprocessState& state) 
       : m_latency_buffer_impl{ latency_buffer_impl }
       , m_raw_processor_impl{ raw_processor_impl }
       , m_processing_delay_ticks{ processing_delay_ticks }
-      , m_post_processing_delay_min_wait{ post_processing_delay_min_wait }
-      , m_post_processing_delay_max_wait{ post_processing_delay_max_wait }
-      , m_max_wait_in_ticks{ post_processing_delay_max_wait * 62500 } // FIXME: hardcoded clock frequency
+      , m_post_processing_delay_min_wait_ms{ post_processing_delay_min_wait_ms }
+      , m_post_processing_delay_max_wait_ms{ post_processing_delay_max_wait_ms }
+      , m_max_wait_in_ticks{ post_processing_delay_max_wait_ms * 62500 } // FIXME: hardcoded clock frequency
       , m_first_cycle{ true }
       , m_state{ state }
       , m_last_post_proc_time{ std::chrono::system_clock::now() }
@@ -211,7 +211,7 @@ protected:
       auto now = std::chrono::system_clock::now();
 
       if (!timeout) { // data arrival
-        if (now - m_last_post_proc_time <= std::chrono::milliseconds(m_post_processing_delay_min_wait)) {
+        if (now - m_last_post_proc_time <= std::chrono::milliseconds(m_post_processing_delay_min_wait_ms)) {
           TLOG_DEBUG(TLVL_WORK_STEPS) << "Not enough time passed since last postprocessing";
           return 0;
         }        
@@ -331,8 +331,8 @@ protected:
     LatencyBufferType& m_latency_buffer_impl;
     RawDataProcessorType& m_raw_processor_impl;
     const uint64_t m_processing_delay_ticks; // NOLINT(build/unsigned)
-    const uint64_t m_post_processing_delay_min_wait; // NOLINT(build/unsigned)
-    const uint64_t m_post_processing_delay_max_wait; // NOLINT(build/unsigned)
+    const uint64_t m_post_processing_delay_min_wait_ms; // NOLINT(build/unsigned)
+    const uint64_t m_post_processing_delay_max_wait_ms; // NOLINT(build/unsigned)
     const timestamp_t m_max_wait_in_ticks;
     bool m_first_cycle;
     PostprocessState& m_state;
@@ -393,8 +393,8 @@ protected:
   daqdataformats::SourceID m_sourceid;
   daqdataformats::run_number_t m_run_number;
   uint64_t m_processing_delay_ticks; // NOLINT(build/unsigned)
-  uint64_t m_post_processing_delay_min_wait; // NOLINT(build/unsigned)
-  uint64_t m_post_processing_delay_max_wait; // NOLINT(build/unsigned)
+  uint64_t m_post_processing_delay_min_wait_ms; // NOLINT(build/unsigned)
+  uint64_t m_post_processing_delay_max_wait_ms; // NOLINT(build/unsigned)
 
   // STATS
   using metric_t = dunedaq::datahandlinglibs::opmon::DataHandlerInfo;

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -6,8 +6,8 @@
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
-#ifndef DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_MODELS_READOUTMODEL_HPP_
-#define DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_MODELS_READOUTMODEL_HPP_
+#ifndef DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_MODELS_DATAHANDLINGMODEL_HPP_
+#define DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_MODELS_DATAHANDLINGMODEL_HPP_
 
 #include "confmodel/DaqModule.hpp"
 #include "confmodel/Connection.hpp"
@@ -34,7 +34,6 @@
 
 #include "datahandlinglibs/ReadoutLogging.hpp"
 #include "datahandlinglibs/concepts/DataHandlingConcept.hpp"
-#include "appmodel/DataHandlerModule.hpp"
 
 #include "datahandlinglibs/DataMoveCallbackRegistry.hpp"
 #include "datahandlinglibs/FrameErrorRegistry.hpp"
@@ -56,6 +55,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <map>
 
 using dunedaq::datahandlinglibs::logging::TLVL_QUEUE_POP;
 using dunedaq::datahandlinglibs::logging::TLVL_TAKE_NOTE;
@@ -241,14 +241,14 @@ protected:
       auto it = start_iter;
 
       for (; it.good(); ++it) {
-        const auto ts = it->get_timestamp();
+        const auto current_ts = it->get_timestamp();
 
         if (timeout) {
-          update_timeout_count(ts);
+          increment_timeout_count(current_ts);
         }
 
-        if (is_too_early_to_process(ts, newest_ts)) {
-          window_end_ts = ts;
+        if (is_too_early_to_postprocess(current_ts, newest_ts)) {
+          window_end_ts = current_ts;
           processed_entire_buffer = false;
           break;
         }
@@ -261,7 +261,7 @@ protected:
           TLOG_DEBUG(TLVL_WORK_STEPS) << "Entire buffer is postprocessed";
           window_end_ts = last_processed_ts + 1; // The loop didn't break and `window_end_ts` wasn't set.
         } else {
-          update_remaining_timeout_counts(it);
+          increment_remaining_timeout_counts(it);
         }
       }
       
@@ -291,12 +291,12 @@ protected:
       m_timeout_count_map.erase(ts);
     }    
 
-    void update_timeout_count(timestamp_t ts)
+    void increment_timeout_count(timestamp_t ts)
     {
       ++m_timeout_count_map[ts];
     }    
 
-    void update_remaining_timeout_counts(auto it)
+    void increment_remaining_timeout_counts(auto it)
     {
       if (it.good()) {
         ++it; // skip 1 because its entry should already be updated in the end window finding loop
@@ -305,7 +305,7 @@ protected:
       }
 
       for (; it.good(); ++it) {
-        update_timeout_count(it->get_timestamp());
+        increment_timeout_count(it->get_timestamp());
       }
     }
 
@@ -315,7 +315,7 @@ protected:
       return (it != m_timeout_count_map.end()) ? it->second : 0;
     }    
 
-    bool is_too_early_to_process(timestamp_t ts, timestamp_t newest_ts) const
+    bool is_too_early_to_postprocess(timestamp_t ts, timestamp_t newest_ts) const
     {
       // An item can be processed if it is "old enough" relative to the newest timestamp. 
       // The age difference must be bigger than the delay ticks we configure; otherwise, it is too early to process.
@@ -380,7 +380,7 @@ protected:
   }
 
   // Operational monitoring
-  virtual void generate_opmon_data() override;
+  void generate_opmon_data() override;
 
   // Constructor params
   std::atomic<bool>& m_run_marker;
@@ -476,4 +476,4 @@ protected:
 // Declarations
 #include "detail/DataHandlingModel.hxx"
 
-#endif // DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_MODELS_READOUTMODEL_HPP_
+#endif // DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_MODELS_DATAHANDLINGMODEL_HPP_

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -408,7 +408,7 @@ protected:
   using num_postprocess_schedule_timeouts_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_postprocess_schedule_timeouts),metric_t>::type>::type;
   using num_postprocess_late_arrivals_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_postprocess_late_arrivals),metric_t>::type>::type;
   using max_postprocess_tick_diff_to_next_window_start_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_tick_diff_to_next_window_start),metric_t>::type>::type;
-  using max_postprocess_tick_distance_to_newest_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_tick_distance_to_newest),metric_t>::type>::type;
+  using max_postprocess_tick_diff_to_newest_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_tick_diff_to_newest),metric_t>::type>::type;
   using max_postprocess_tick_diff_to_last_processed_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_tick_diff_to_last_processed),metric_t>::type>::type;
 
   std::atomic<num_payload_t> m_num_payloads{ 0 };
@@ -420,7 +420,7 @@ protected:
   std::atomic<num_postprocess_schedule_timeouts_t> m_num_postprocess_schedule_timeouts{ 0 };
   std::atomic<num_postprocess_late_arrivals_t> m_num_postprocess_late_arrivals{ 0 };
   std::atomic<max_postprocess_tick_diff_to_next_window_start_t> m_max_postprocess_tick_diff_to_next_window_start{ 0 };
-  std::atomic<max_postprocess_tick_distance_to_newest_t> m_max_postprocess_tick_distance_to_newest{ 0 };
+  std::atomic<max_postprocess_tick_diff_to_newest_t> m_max_postprocess_tick_diff_to_newest{ 0 };
   std::atomic<max_postprocess_tick_diff_to_last_processed_t> m_max_postprocess_tick_diff_to_last_processed{ 0 };
   std::atomic<int> m_stats_packet_count{ 0 };
 

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -136,146 +136,214 @@ protected:
   class PostprocessScheduleAlgorithm
   {
   public:
+    struct PostprocessState {
+      timestamp_t next_window_start_ts{ 0 };
+      timestamp_t last_processed_ts{ 0 };
+    };
+
     PostprocessScheduleAlgorithm(LatencyBufferType& latency_buffer_impl,
                                  RawDataProcessorType& raw_processor_impl,
                                  uint64_t processing_delay_ticks, // NOLINT(build/unsigned)
                                  uint64_t post_processing_delay_min_wait, // NOLINT(build/unsigned)
-                                 uint64_t post_processing_delay_max_wait) // NOLINT(build/unsigned)
+                                 uint64_t post_processing_delay_max_wait, // NOLINT(build/unsigned)
+                                 PostprocessState& state,
+                                 std::mutex& state_mutex) 
       : m_latency_buffer_impl{ latency_buffer_impl }
       , m_raw_processor_impl{ raw_processor_impl }
       , m_processing_delay_ticks{ processing_delay_ticks }
       , m_post_processing_delay_min_wait{ post_processing_delay_min_wait }
       , m_post_processing_delay_max_wait{ post_processing_delay_max_wait }
       , m_first_cycle{ true }
-      , m_processed_up_to{}
+      , m_next_window_start{}
+      , m_state{ state }
+      , m_state_mutex{ state_mutex }
       , m_last_post_proc_time{ std::chrono::system_clock::now() }
-      , m_consecutive_timeouts{ 0 }
       , m_max_wait_in_ticks{ post_processing_delay_max_wait * 62500 } // FIXME: hardcoded clock frequency
     {
-    }
+    }   
 
     // High-level interface
     // Schedule deferred post-processing and notify timeout expiration to the processor
     int run(bool timeout) {
       int processed = this->do_run(timeout);
 
-      if (timeout) {
-        timestamp_t timeout_accumulated = m_consecutive_timeouts * m_max_wait_in_ticks;
-        m_raw_processor_impl.invoke_postprocess_schedule_timeout_policy(timeout_accumulated);
-      }
+      // if (timeout) {
+      //   timestamp_t timeout_accumulated = m_consecutive_timeouts * m_max_wait_in_ticks;
+      //   m_raw_processor_impl.invoke_postprocess_schedule_timeout_policy(timeout_accumulated);
+      // }
 
       return processed;
     }
-
 
     // Deferral of the post processing, to allow elements being reordered in the LB
     // Basically, find data older than a certain timestamp and process all data since the last post-processed element up to that value
     int do_run(bool timeout)
     {
       if (m_latency_buffer_impl.occupancy() == 0) {
-        TLOG_DEBUG(TLVL_WORK_STEPS) << "Nothing to postprocess (empty buffer)";
+        TLOG() << "Nothing to postprocess (empty buffer)";
         return 0;
       }
 
       if (m_first_cycle) {
+        m_timeout_counts.push_back(0);
+
         auto head = m_latency_buffer_impl.front();
-        m_processed_up_to.set_timestamp(head->get_timestamp());
+
+        m_next_window_start.set_timestamp(head->get_timestamp());
+        set_postprocessing_state(m_next_window_start.get_timestamp(), 0);
+
         m_first_cycle = false;
+
         TLOG() << "***** First pass post processing *****";
+        return 0;
       }
 
       // Get the LB boundaries
       auto tail = m_latency_buffer_impl.back();
       auto newest_ts = tail->get_timestamp();
-
-      timestamp_t end_win_ts = 0;
+      
       std::chrono::time_point<std::chrono::system_clock> now{ std::chrono::system_clock::now() };
 
       if (timeout) {
-        // Return if the last processed timestamp is greater than the newest timestamp
-        // This condition occurs after a timeout
-        if (m_processed_up_to.get_timestamp() >= newest_ts + 1) {
-          TLOG_DEBUG(TLVL_WORK_STEPS) << "Nothing to postprocess (at or past cap)";
+        if (m_next_window_start.get_timestamp() >= newest_ts + 1) {
+          TLOG() << "Nothing to postprocess (all items are processed already)";
           return 0;
         }
 
-        ++m_consecutive_timeouts;
-        timestamp_t timeout_accumulated = m_consecutive_timeouts * m_max_wait_in_ticks;
-
-        end_win_ts = newest_ts - m_processing_delay_ticks + timeout_accumulated;
-        end_win_ts = std::min(end_win_ts, newest_ts + 1); // Cap to prevent end_win_ts from becoming unnecessarily large
-      } else {
-        m_consecutive_timeouts = 0;
-
-        if (m_processed_up_to.get_timestamp() >= newest_ts + 1) {
-          TLOG_DEBUG(TLVL_WORK_STEPS) << "Nothing to postprocess (data arrived too late, will be ignored)";
+        for (auto& count : m_timeout_counts) {
+          ++count;
+        }      
+      } else { // data arrival
+        if (m_next_window_start.get_timestamp() >= newest_ts + 1) {
+          TLOG() << "Nothing to postprocess (data arrived for a closed processing window, all items are processed already)";
           return 0;
         }
+                
+        m_timeout_counts.push_back(0);
 
         auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_post_proc_time);
-
-        if (milliseconds.count() > m_post_processing_delay_min_wait) {
-          if (newest_ts - m_processed_up_to.get_timestamp() > m_processing_delay_ticks) {
-            end_win_ts = newest_ts - m_processing_delay_ticks;
-          } else {
-            TLOG_DEBUG(TLVL_WORK_STEPS) << "Not ready to postprocess (m_processing_delay_ticks is greater)";
-            return 0;
-          }
-        } else {
-          TLOG_DEBUG(TLVL_WORK_STEPS) << "Not ready to postprocess (too fast)";
+        if (milliseconds.count() <= m_post_processing_delay_min_wait) {
+          TLOG() << "Not ready to postprocess (too fast)";
           return 0;
-        }
+        }        
       }
-
-      auto start_iter = m_latency_buffer_impl.lower_bound(m_processed_up_to, false);
-      m_processed_up_to.set_timestamp(end_win_ts);
-      auto end_iter = m_latency_buffer_impl.lower_bound(m_processed_up_to, false);
+            
+      timestamp_t ts_window_end = newest_ts + 1;
+      size_t timeout_idx = 0;
+      
+      auto start_iter = m_latency_buffer_impl.lower_bound(m_next_window_start, false);
 
       // This likely happens when RDT uses a composite key
       // The current algorithm does not support composite keys
-      // Our search item `m_processed_up_to` will have its other keys set to their defaults
+      // Our search item `m_next_window_start` will have its other keys set to their defaults
       // E.g., for TriggerPrimitive, channel = INVALID_TP_CHANNEL
       // Even if an entry with the same ts exists in the buffer, its channel will be a valid (smaller) value,
       // so `lower_bound` will not be able to find it
       // We should verify that this is the only scenario in which we end up here
       if (!start_iter.good()) {
-        TLOG_DEBUG(TLVL_WORK_STEPS) << "Nothing to postprocess (!start_iter.good())";
+        TLOG() << "Nothing to postprocess (!start_iter.good())";
         return 0;
       }
 
+      auto it = start_iter;
+      while (true) {
+        // Just to be completely safe
+        // We should understand why we end up here
+        if (!it.good()) {
+          TLOG() << "Invalid iterator during end window find loop";
+          return 0;
+        }
+
+        auto ts = it->get_timestamp();
+        auto effective_ts = get_effective_ts(ts, timeout_idx);
+        int64_t newest_ts_signed = static_cast<int64_t>(newest_ts);
+        int64_t delay_ticks_signed = static_cast<int64_t>(m_processing_delay_ticks);
+
+        if (newest_ts_signed - effective_ts <= delay_ticks_signed) {
+          ts_window_end = ts;
+          break;
+        }
+
+        if (&(*it) == tail) {
+          break;
+        }
+        ++it;
+        ++timeout_idx;
+      }
+
+      if (ts_window_end == newest_ts + 1) {
+        TLOG() << "This will process everything";
+      }
+
+      RDT window_end = m_next_window_start;
+      window_end.set_timestamp(ts_window_end);
+      auto end_iter = m_latency_buffer_impl.lower_bound(window_end, false);
+
       if (start_iter == end_iter) {
-        TLOG_DEBUG(TLVL_WORK_STEPS) << "Nothing to postprocess (start_iter == end_iter)";
+        TLOG() << "Nothing to postprocess (start_iter == end_iter)";
         return 0;
       }
 
       int processed = 0;
+      auto last_processed_ts = get_last_processed_ts();
       for (auto it = start_iter; it != end_iter; ++it) {
         // Just to be completely safe
         // We should understand why we end up here
         if (!it.good()) {
-          TLOG_DEBUG(TLVL_WORK_STEPS) << "Invalid iterator in postprocessing loop";
+          TLOG() << "Invalid iterator in postprocessing loop";
           break;
         }
         m_raw_processor_impl.postprocess_item(&(*it));
+        last_processed_ts = it->get_timestamp();
         ++processed;
       }
 
+      m_next_window_start.set_timestamp(ts_window_end);
+      set_postprocessing_state(ts_window_end, last_processed_ts);
+
       m_last_post_proc_time = now;
+
+      if (processed > 0) {
+        m_timeout_counts.erase(m_timeout_counts.begin(),
+                               m_timeout_counts.begin() + processed);
+      }
 
       return processed;
     }
 
   private:
+    timestamp_t get_last_processed_ts()
+    {
+      std::lock_guard<std::mutex> lock(m_state_mutex);
+      return m_state.last_processed_ts;
+    }
+
+    void set_postprocessing_state(timestamp_t next_window_start_ts, timestamp_t last_processed_ts)
+    {
+      std::lock_guard<std::mutex> lock(m_state_mutex);
+      m_state.next_window_start_ts = next_window_start_ts;
+      m_state.last_processed_ts = last_processed_ts;
+    }
+
+    int64_t get_effective_ts(timestamp_t ts, size_t timeout_idx) {
+      int64_t virtual_age = 
+        static_cast<int64_t>(m_timeout_counts[timeout_idx]) * static_cast<int64_t>(m_max_wait_in_ticks);
+
+      return static_cast<int64_t>(ts) - virtual_age;
+    }
+
     LatencyBufferType& m_latency_buffer_impl;
     RawDataProcessorType& m_raw_processor_impl;
     const uint64_t m_processing_delay_ticks; // NOLINT(build/unsigned)
     const uint64_t m_post_processing_delay_min_wait; // NOLINT(build/unsigned)
     const uint64_t m_post_processing_delay_max_wait; // NOLINT(build/unsigned)
     bool m_first_cycle;
-    RDT m_processed_up_to;
-    int m_consecutive_timeouts;
+    RDT m_next_window_start;
+    PostprocessState& m_state;
+    std::mutex& m_state_mutex;
+    std::vector<std::size_t> m_timeout_counts;
     const timestamp_t m_max_wait_in_ticks;
-    std::chrono::time_point<std::chrono::system_clock> m_last_post_proc_time;
+    std::chrono::time_point<std::chrono::system_clock> m_last_post_proc_time;    
   };
 
   // Perform processing operations on payload
@@ -339,7 +407,10 @@ protected:
   using sum_request_t = std::remove_const<std::invoke_result<decltype(&metric_t::sum_requests),metric_t>::type>::type;
   using rawq_timeout_count_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_data_input_timeouts),metric_t>::type>::type;
   using num_lb_insert_failures_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_lb_insert_failures),metric_t>::type>::type;
-  using num_post_processing_delay_max_waits_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_post_processing_delay_max_waits),metric_t>::type>::type;
+  using num_postprocess_schedule_timeouts_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_postprocess_schedule_timeouts),metric_t>::type>::type;
+  using num_postprocess_late_arrivals_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_postprocess_late_arrivals),metric_t>::type>::type;
+  using postprocess_lateness_from_last_processed_t = std::remove_const<std::invoke_result<decltype(&metric_t::postprocess_lateness_from_last_processed),metric_t>::type>::type;
+  using postprocess_lateness_from_newest_t = std::remove_const<std::invoke_result<decltype(&metric_t::postprocess_lateness_from_newest),metric_t>::type>::type;
 
   std::atomic<num_payload_t> m_num_payloads{ 0 };
   std::atomic<sum_payload_t> m_sum_payloads{ 0 };
@@ -347,7 +418,10 @@ protected:
   std::atomic<sum_request_t> m_sum_requests{ 0 };
   std::atomic<rawq_timeout_count_t> m_rawq_timeout_count{ 0 };
   std::atomic<num_lb_insert_failures_t> m_num_lb_insert_failures{ 0 };
-  std::atomic<num_post_processing_delay_max_waits_t> m_num_post_processing_delay_max_waits{ 0 };
+  std::atomic<num_postprocess_schedule_timeouts_t> m_num_postprocess_schedule_timeouts{ 0 };
+  std::atomic<num_postprocess_late_arrivals_t> m_num_postprocess_late_arrivals{ 0 };
+  std::atomic<postprocess_lateness_from_last_processed_t> m_postprocess_lateness_from_last_processed{ 0 };
+  std::atomic<postprocess_lateness_from_newest_t> m_postprocess_lateness_from_newest{ 0 };
   std::atomic<int> m_stats_packet_count{ 0 };
 
   // CONSUMER
@@ -380,6 +454,8 @@ protected:
   utilities::ReusableThread m_postprocess_scheduler_thread;
   folly::coro::Baton m_baton;
   std::unique_ptr<folly::Timekeeper> m_timekeeper;
+  PostprocessScheduleAlgorithm::PostprocessState m_postprocess_state;
+  std::mutex m_postprocess_state_mutex;  
 
   // LATENCY BUFFER
   std::shared_ptr<LatencyBufferType> m_latency_buffer_impl;

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -395,7 +395,8 @@ protected:
   uint64_t m_processing_delay_ticks; // NOLINT(build/unsigned)
   uint64_t m_post_processing_delay_min_wait_ms; // NOLINT(build/unsigned)
   uint64_t m_post_processing_delay_max_wait_ms; // NOLINT(build/unsigned)
-
+  bool m_post_processing_delay_monitor_late_tick_diffs_only;
+  
   // STATS
   using metric_t = dunedaq::datahandlinglibs::opmon::DataHandlerInfo;
   using num_payload_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_payloads),metric_t>::type>::type;
@@ -406,9 +407,9 @@ protected:
   using num_lb_insert_failures_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_lb_insert_failures),metric_t>::type>::type;
   using num_postprocess_schedule_timeouts_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_postprocess_schedule_timeouts),metric_t>::type>::type;
   using num_postprocess_late_arrivals_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_postprocess_late_arrivals),metric_t>::type>::type;
-  using max_postprocess_distance_from_next_window_start_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_distance_from_next_window_start),metric_t>::type>::type;
-  using max_postprocess_distance_from_newest_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_distance_from_newest),metric_t>::type>::type;
-  using max_postprocess_distance_from_last_processed_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_distance_from_last_processed),metric_t>::type>::type;
+  using max_postprocess_tick_diff_to_next_window_start_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_tick_diff_to_next_window_start),metric_t>::type>::type;
+  using max_postprocess_tick_distance_to_newest_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_tick_distance_to_newest),metric_t>::type>::type;
+  using max_postprocess_tick_diff_to_last_processed_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_tick_diff_to_last_processed),metric_t>::type>::type;
 
   std::atomic<num_payload_t> m_num_payloads{ 0 };
   std::atomic<sum_payload_t> m_sum_payloads{ 0 };
@@ -418,9 +419,9 @@ protected:
   std::atomic<num_lb_insert_failures_t> m_num_lb_insert_failures{ 0 };
   std::atomic<num_postprocess_schedule_timeouts_t> m_num_postprocess_schedule_timeouts{ 0 };
   std::atomic<num_postprocess_late_arrivals_t> m_num_postprocess_late_arrivals{ 0 };
-  std::atomic<max_postprocess_distance_from_next_window_start_t> m_max_postprocess_distance_from_next_window_start{ 0 };
-  std::atomic<max_postprocess_distance_from_newest_t> m_max_postprocess_distance_from_newest{ 0 };
-  std::atomic<max_postprocess_distance_from_last_processed_t> m_max_postprocess_distance_from_last_processed{ 0 };
+  std::atomic<max_postprocess_tick_diff_to_next_window_start_t> m_max_postprocess_tick_diff_to_next_window_start{ 0 };
+  std::atomic<max_postprocess_tick_distance_to_newest_t> m_max_postprocess_tick_distance_to_newest{ 0 };
+  std::atomic<max_postprocess_tick_diff_to_last_processed_t> m_max_postprocess_tick_diff_to_last_processed{ 0 };
   std::atomic<int> m_stats_packet_count{ 0 };
 
   // CONSUMER

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -187,14 +187,7 @@ protected:
       }
 
       if (m_first_cycle) { // first data arrival
-        auto head = m_latency_buffer_impl.front();
-        auto oldest_ts = head->get_timestamp();
-        
-        set_postprocessing_state(oldest_ts, 0);
-
-        m_first_cycle = false;
-
-        TLOG() << "***** First pass post processing *****";
+        handle_first_cycle();
         return 0;
       }
 
@@ -204,8 +197,8 @@ protected:
 
       const auto next_window_start_ts = get_next_window_start_ts();
       
-      if (next_window_start_ts >= newest_ts + 1) {
-        TLOG() << "Nothing to postprocess (all items are processed already)";
+      if (next_window_start_ts > newest_ts) {
+        TLOG() << "Postprocessing window is already closed";
         return 0;
       }
 
@@ -214,7 +207,7 @@ protected:
       if (!m_is_timeout) { // data arrival
         auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_post_proc_time);
         if (milliseconds.count() <= m_post_processing_delay_min_wait) {
-          TLOG_DEBUG(TLVL_WORK_STEPS) << "Not ready to postprocess (too fast)";
+          TLOG_DEBUG(TLVL_WORK_STEPS) << "Not enough time passed since last postprocessing";
           return 0;
         }        
       }
@@ -256,18 +249,13 @@ protected:
         postprocess_item(&(*it), processed, last_processed_ts);
       }
 
+      set_postprocessing_state(window_end_ts, last_processed_ts);
+
       if (window_end_ts == newest_ts + 1) {
-        if (it.good()) {
-          TLOG() << "Processing entire buffer";
-          postprocess_item(&(*it), processed, last_processed_ts);
-        } else {
-          TLOG() << "Unexpected delayed postprocessing state: iterator invalid when processing entire buffer";
-        }
+        TLOG() << "Entire buffer was postprocessed";
       } else {
         update_remaining_timeout_counts(it);
       }
-
-      set_postprocessing_state(window_end_ts, last_processed_ts);
 
       m_last_post_proc_time = now;
 
@@ -294,6 +282,16 @@ protected:
       m_state.last_processed_ts = last_processed_ts;
     }
 
+    void handle_first_cycle() {
+      auto head = m_latency_buffer_impl.front();
+      auto oldest_ts = head->get_timestamp();
+      
+      set_postprocessing_state(oldest_ts, 0);
+
+      m_first_cycle = false;
+      TLOG() << "***** First pass post processing *****";
+    }
+
     void postprocess_item(const ReadoutType* item, size_t& processed, timestamp_t& last_processed_ts)
     {
       m_raw_processor_impl.postprocess_item(item);
@@ -315,8 +313,8 @@ protected:
     void update_remaining_timeout_counts(auto it)
     {
       if (it.good()) { 
-        ++it; // skip 1 because its entry should already be updated in the window finding loop
-      } else {
+        ++it; // skip 1 because its entry should already be updated in the end window finding loop
+      } else [[unlikely]] {
         TLOG() << "Unexpected delayed postprocessing state: iterator invalid before updating remaining timeouts";
       }
 
@@ -326,12 +324,20 @@ protected:
     }    
 
     int64_t get_effective_ts(timestamp_t ts) const {
-      const auto timeout_count = m_timeout_count_map.at(ts);
+      const auto ts_signed = static_cast<int64_t>(ts);
+      const auto it = m_timeout_count_map.find(ts);
+
+      if (it == m_timeout_count_map.end()) [[unlikely]] {
+        TLOG() << "Unexpected delayed postprocessing state: missing timeout count for " << ts;
+        return ts_signed;
+      }
+
+      const auto timeout_count = it->second;      
 
       const int64_t virtual_age =
         static_cast<int64_t>(timeout_count) * static_cast<int64_t>(m_max_wait_in_ticks);
 
-      return static_cast<int64_t>(ts) - virtual_age;
+      return ts_signed - virtual_age;
     }
 
     bool is_not_ready_for_processing(timestamp_t newest_ts, int64_t effective_ts) const

--- a/include/datahandlinglibs/models/DataHandlingModel.hpp
+++ b/include/datahandlinglibs/models/DataHandlingModel.hpp
@@ -406,8 +406,9 @@ protected:
   using num_lb_insert_failures_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_lb_insert_failures),metric_t>::type>::type;
   using num_postprocess_schedule_timeouts_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_postprocess_schedule_timeouts),metric_t>::type>::type;
   using num_postprocess_late_arrivals_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_postprocess_late_arrivals),metric_t>::type>::type;
-  using postprocess_lateness_from_last_processed_t = std::remove_const<std::invoke_result<decltype(&metric_t::postprocess_lateness_from_last_processed),metric_t>::type>::type;
-  using postprocess_lateness_from_newest_t = std::remove_const<std::invoke_result<decltype(&metric_t::postprocess_lateness_from_newest),metric_t>::type>::type;
+  using max_postprocess_distance_from_next_window_start_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_distance_from_next_window_start),metric_t>::type>::type;
+  using max_postprocess_distance_from_newest_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_distance_from_newest),metric_t>::type>::type;
+  using max_postprocess_distance_from_last_processed_t = std::remove_const<std::invoke_result<decltype(&metric_t::max_postprocess_distance_from_last_processed),metric_t>::type>::type;
 
   std::atomic<num_payload_t> m_num_payloads{ 0 };
   std::atomic<sum_payload_t> m_sum_payloads{ 0 };
@@ -417,8 +418,9 @@ protected:
   std::atomic<num_lb_insert_failures_t> m_num_lb_insert_failures{ 0 };
   std::atomic<num_postprocess_schedule_timeouts_t> m_num_postprocess_schedule_timeouts{ 0 };
   std::atomic<num_postprocess_late_arrivals_t> m_num_postprocess_late_arrivals{ 0 };
-  std::atomic<postprocess_lateness_from_last_processed_t> m_postprocess_lateness_from_last_processed{ 0 };
-  std::atomic<postprocess_lateness_from_newest_t> m_postprocess_lateness_from_newest{ 0 };
+  std::atomic<max_postprocess_distance_from_next_window_start_t> m_max_postprocess_distance_from_next_window_start{ 0 };
+  std::atomic<max_postprocess_distance_from_newest_t> m_max_postprocess_distance_from_newest{ 0 };
+  std::atomic<max_postprocess_distance_from_last_processed_t> m_max_postprocess_distance_from_last_processed{ 0 };
   std::atomic<int> m_stats_packet_count{ 0 };
 
   // CONSUMER

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -225,7 +225,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
   ri.set_sum_requests(m_sum_requests.load());
   ri.set_num_requests(m_num_requests.exchange(0));
   ri.set_num_postprocess_schedule_timeouts(m_num_postprocess_schedule_timeouts.exchange(0));
-  ri.set_num_postprocess_late_arrivals(m_num_postprocess_late_arrivals.load());
+  ri.set_num_postprocess_late_arrivals(m_num_postprocess_late_arrivals.exchange(0));
   ri.set_max_postprocess_tick_diff_to_next_window_start(m_max_postprocess_tick_diff_to_next_window_start.exchange(std::numeric_limits<max_postprocess_tick_diff_to_next_window_start_t>::min()));
   ri.set_max_postprocess_tick_diff_to_newest(m_max_postprocess_tick_diff_to_newest.exchange(std::numeric_limits<max_postprocess_tick_diff_to_newest_t>::min()));
   ri.set_max_postprocess_tick_diff_to_last_processed(m_max_postprocess_tick_diff_to_last_processed.exchange(std::numeric_limits<max_postprocess_tick_diff_to_last_processed_t>::min()));

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -75,7 +75,8 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerModu
   m_processing_delay_ticks = mcfg->get_module_configuration()->get_post_processing_delay_ticks();
   m_post_processing_delay_min_wait_ms = mcfg->get_module_configuration()->get_post_processing_delay_min_wait_ms();
   m_post_processing_delay_max_wait_ms = mcfg->get_module_configuration()->get_post_processing_delay_max_wait_ms();
-
+  m_post_processing_delay_monitor_late_tick_diffs_only = mcfg->get_module_configuration()->get_post_processing_delay_monitor_late_tick_diffs_only();
+  
   if (m_processing_delay_ticks) {
     if constexpr (!SupportsDelayedPostprocessing<LBT>) {
       ers::error(ConfigurationError(
@@ -139,9 +140,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const appfwk::DAQModule::Comma
   m_rawq_timeout_count = 0;
   m_num_postprocess_schedule_timeouts = 0;
   m_num_postprocess_late_arrivals = 0;
-  m_max_postprocess_distance_from_next_window_start = 0;
-  m_max_postprocess_distance_from_newest = 0;
-  m_max_postprocess_distance_from_last_processed = 0;
+  m_max_postprocess_tick_diff_to_next_window_start = 0;
+  m_max_postprocess_tick_distance_to_newest = 0;
+  m_max_postprocess_tick_diff_to_last_processed = 0;
 
   m_t0 = std::chrono::high_resolution_clock::now();
 
@@ -225,9 +226,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
   ri.set_num_requests(m_num_requests.exchange(0));
   ri.set_num_postprocess_schedule_timeouts(m_num_postprocess_schedule_timeouts.exchange(0));
   ri.set_num_postprocess_late_arrivals(m_num_postprocess_late_arrivals.load());
-  ri.set_max_postprocess_distance_from_next_window_start(m_max_postprocess_distance_from_next_window_start.exchange(0));
-  ri.set_max_postprocess_distance_from_newest(m_max_postprocess_distance_from_newest.exchange(0));
-  ri.set_max_postprocess_distance_from_last_processed(m_max_postprocess_distance_from_last_processed.exchange(0));
+  ri.set_max_postprocess_tick_diff_to_next_window_start(m_max_postprocess_tick_diff_to_next_window_start.exchange(0));
+  ri.set_max_postprocess_tick_distance_to_newest(m_max_postprocess_tick_distance_to_newest.exchange(0));
+  ri.set_max_postprocess_tick_diff_to_last_processed(m_max_postprocess_tick_diff_to_last_processed.exchange(0));
   ri.set_last_daq_timestamp(m_raw_processor_impl->get_last_daq_time());
   ri.set_newest_timestamp(m_raw_processor_impl->get_last_daq_time());
   ri.set_oldest_timestamp(m_request_handler_impl->get_oldest_time());
@@ -283,26 +284,31 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT&& payload)
     auto next_window_start_ts = m_postprocess_state.next_window_start_ts.load(std::memory_order_relaxed);
     auto last_processed_ts = m_postprocess_state.last_processed_ts.load(std::memory_order_relaxed);
     
-    if (next_window_start_ts > payload_ts) {
+    auto is_late_arrival = next_window_start_ts > payload_ts;
+
+    if (is_late_arrival) {
       ++m_num_postprocess_late_arrivals;
+    }
 
-      auto distance_from_next_window_start = next_window_start_ts - payload_ts;
+    if (is_late_arrival || !m_post_processing_delay_monitor_late_tick_diffs_only) {
+      auto diff_to_next_window_start =
+        static_cast<int64_t>(next_window_start_ts) - static_cast<int64_t>(payload_ts);
 
-      if (distance_from_next_window_start > m_max_postprocess_distance_from_next_window_start.load()) {
-        m_max_postprocess_distance_from_next_window_start.store(distance_from_next_window_start);
+      if (diff_to_next_window_start > m_max_postprocess_tick_diff_to_next_window_start.load()) {
+        m_max_postprocess_tick_diff_to_next_window_start.store(diff_to_next_window_start);
       }      
 
-      auto distance_from_newest = m_latency_buffer_impl->back()->get_timestamp() - payload_ts;
+      auto distance_to_newest = m_latency_buffer_impl->back()->get_timestamp() - payload_ts;
 
-      if (distance_from_newest > m_max_postprocess_distance_from_newest.load()) {
-        m_max_postprocess_distance_from_newest.store(distance_from_newest);
+      if (distance_to_newest > m_max_postprocess_tick_distance_to_newest.load()) {
+        m_max_postprocess_tick_distance_to_newest.store(distance_to_newest);
       }
 
-      auto distance_from_last_processed =
-        (last_processed_ts > payload_ts) ? (last_processed_ts - payload_ts) : 0; // Maybe smaller because of inconsistent state
+      auto diff_to_last_processed =
+        static_cast<int64_t>(last_processed_ts) - static_cast<int64_t>(payload_ts);
       
-      if (distance_from_last_processed > m_max_postprocess_distance_from_last_processed.load()) {
-        m_max_postprocess_distance_from_last_processed.store(distance_from_last_processed);
+      if (diff_to_last_processed > m_max_postprocess_tick_diff_to_last_processed.load()) {
+        m_max_postprocess_tick_diff_to_last_processed.store(diff_to_last_processed);
       }      
     }
   }
@@ -343,9 +349,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
   m_stats_packet_count = 0;
   m_num_postprocess_schedule_timeouts = 0;
   m_num_postprocess_late_arrivals = 0;
-  m_max_postprocess_distance_from_next_window_start = 0;  
-  m_max_postprocess_distance_from_newest = 0;  
-  m_max_postprocess_distance_from_last_processed = 0;
+  m_max_postprocess_tick_diff_to_next_window_start = 0;  
+  m_max_postprocess_tick_distance_to_newest = 0;  
+  m_max_postprocess_tick_diff_to_last_processed = 0;
 
   while (m_run_marker.load()) {
     // Try to acquire data

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -139,8 +139,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const appfwk::DAQModule::Comma
   m_rawq_timeout_count = 0;
   m_num_postprocess_schedule_timeouts = 0;
   m_num_postprocess_late_arrivals = 0;
-  m_postprocess_lateness_from_last_processed = 0;
-  m_postprocess_lateness_from_newest = 0;
+  m_max_postprocess_distance_from_next_window_start = 0;
+  m_max_postprocess_distance_from_newest = 0;
+  m_max_postprocess_distance_from_last_processed = 0;
 
   m_t0 = std::chrono::high_resolution_clock::now();
 
@@ -224,8 +225,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
   ri.set_num_requests(m_num_requests.exchange(0));
   ri.set_num_postprocess_schedule_timeouts(m_num_postprocess_schedule_timeouts.exchange(0));
   ri.set_num_postprocess_late_arrivals(m_num_postprocess_late_arrivals.load());
-  ri.set_postprocess_lateness_from_last_processed(m_postprocess_lateness_from_last_processed.load());
-  ri.set_postprocess_lateness_from_newest(m_postprocess_lateness_from_newest.load());
+  ri.set_max_postprocess_distance_from_next_window_start(m_max_postprocess_distance_from_next_window_start.exchange(0));
+  ri.set_max_postprocess_distance_from_newest(m_max_postprocess_distance_from_newest.exchange(0));
+  ri.set_max_postprocess_distance_from_last_processed(m_max_postprocess_distance_from_last_processed.exchange(0));
   ri.set_last_daq_timestamp(m_raw_processor_impl->get_last_daq_time());
   ri.set_newest_timestamp(m_raw_processor_impl->get_last_daq_time());
   ri.set_oldest_timestamp(m_request_handler_impl->get_oldest_time());
@@ -281,15 +283,27 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT&& payload)
     auto next_window_start_ts = m_postprocess_state.next_window_start_ts.load(std::memory_order_relaxed);
     auto last_processed_ts = m_postprocess_state.last_processed_ts.load(std::memory_order_relaxed);
     
-    if (payload_ts < next_window_start_ts) {
+    if (next_window_start_ts > payload_ts) {
       ++m_num_postprocess_late_arrivals;
+
+      auto distance_from_next_window_start = next_window_start_ts - payload_ts;
+
+      if (distance_from_next_window_start > m_max_postprocess_distance_from_next_window_start.load()) {
+        m_max_postprocess_distance_from_next_window_start.store(distance_from_next_window_start);
+      }      
+
+      auto distance_from_newest = m_latency_buffer_impl->back()->get_timestamp() - payload_ts;
+
+      if (distance_from_newest > m_max_postprocess_distance_from_newest.load()) {
+        m_max_postprocess_distance_from_newest.store(distance_from_newest);
+      }
+
+      auto distance_from_last_processed =
+        (last_processed_ts > payload_ts) ? (last_processed_ts - payload_ts) : 0; // Maybe smaller because of inconsistent state
       
-      // Maybe smaller because of inconsistent state
-      auto lateness_from_last_processed =
-        (last_processed_ts > payload_ts) ? (last_processed_ts - payload_ts) : 0;      
-      m_postprocess_lateness_from_last_processed.store(lateness_from_last_processed);
-      
-      m_postprocess_lateness_from_newest.store(m_latency_buffer_impl->back()->get_timestamp() - payload_ts);
+      if (distance_from_last_processed > m_max_postprocess_distance_from_last_processed.load()) {
+        m_max_postprocess_distance_from_last_processed.store(distance_from_last_processed);
+      }      
     }
   }
 
@@ -329,8 +343,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
   m_stats_packet_count = 0;
   m_num_postprocess_schedule_timeouts = 0;
   m_num_postprocess_late_arrivals = 0;
-  m_postprocess_lateness_from_last_processed = 0;
-  m_postprocess_lateness_from_newest = 0;  
+  m_max_postprocess_distance_from_next_window_start = 0;  
+  m_max_postprocess_distance_from_newest = 0;  
+  m_max_postprocess_distance_from_last_processed = 0;
 
   while (m_run_marker.load()) {
     // Try to acquire data

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -73,8 +73,8 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerModu
   m_sourceid.id = mcfg->get_source_id();
   m_sourceid.subsystem = RDT::subsystem;
   m_processing_delay_ticks = mcfg->get_module_configuration()->get_post_processing_delay_ticks();
-  m_post_processing_delay_min_wait = mcfg->get_module_configuration()->get_post_processing_delay_min_wait();
-  m_post_processing_delay_max_wait = mcfg->get_module_configuration()->get_post_processing_delay_max_wait();
+  m_post_processing_delay_min_wait_ms = mcfg->get_module_configuration()->get_post_processing_delay_min_wait_ms();
+  m_post_processing_delay_max_wait_ms = mcfg->get_module_configuration()->get_post_processing_delay_max_wait_ms();
 
   if (m_processing_delay_ticks) {
     if constexpr (!SupportsDelayedPostprocessing<LBT>) {
@@ -371,13 +371,13 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule()
 {
 
   TLOG_DEBUG(TLVL_WORK_STEPS) << "Postprocess schedule coroutine started...";
-  TLOG() << "***** Starting post-process coroutine with timout " << m_post_processing_delay_max_wait << " *****";
+  TLOG() << "***** Starting post-process coroutine with timout " << m_post_processing_delay_max_wait_ms << " *****";
 
   PostprocessScheduleAlgorithm sched_algo{ *m_latency_buffer_impl,
                                            *m_raw_processor_impl,
                                            m_processing_delay_ticks,
-                                           m_post_processing_delay_min_wait,
-                                           m_post_processing_delay_max_wait,
+                                           m_post_processing_delay_min_wait_ms,
+                                           m_post_processing_delay_max_wait_ms,
                                            m_postprocess_state };
 
   const auto wait_data = [this]() -> folly::coro::Task<void> {
@@ -391,10 +391,10 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule()
   while (m_run_marker.load()) {
     bool timeout = false;
 
-    if (m_post_processing_delay_max_wait > 0) {
+    if (m_post_processing_delay_max_wait_ms > 0) {
       try {
         co_await folly::coro::timeout(
-          wait_data(), std::chrono::milliseconds{ m_post_processing_delay_max_wait }, m_timekeeper.get());
+          wait_data(), std::chrono::milliseconds{ m_post_processing_delay_max_wait_ms }, m_timekeeper.get());
 
       } catch (const folly::FutureTimeout&) {
         timeout = true;

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -277,18 +277,18 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT&& payload)
   }
 
   if (m_processing_delay_ticks > 0) {
-    timestamp_t next_window_start_ts;
-    timestamp_t last_processed_ts;
-
-    {
-      std::lock_guard<std::mutex> lock(m_postprocess_state_mutex);
-      next_window_start_ts = m_postprocess_state.next_window_start_ts;
-      last_processed_ts = m_postprocess_state.last_processed_ts;
-    }
-
+    // May not belong to the same state but we accept this possibility of inconsistency
+    auto next_window_start_ts = m_postprocess_state.next_window_start_ts.load(std::memory_order_relaxed);
+    auto last_processed_ts = m_postprocess_state.last_processed_ts.load(std::memory_order_relaxed);
+    
     if (payload_ts < next_window_start_ts) {
       ++m_num_postprocess_late_arrivals;
-      m_postprocess_lateness_from_last_processed.store(last_processed_ts - payload_ts);
+      
+      // Maybe smaller because of inconsistent state
+      auto lateness_from_last_processed =
+        (last_processed_ts > payload_ts) ? (last_processed_ts - payload_ts) : 0;      
+      m_postprocess_lateness_from_last_processed.store(lateness_from_last_processed);
+      
       m_postprocess_lateness_from_newest.store(m_latency_buffer_impl->back()->get_timestamp() - payload_ts);
     }
   }
@@ -363,8 +363,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule()
                                            m_processing_delay_ticks,
                                            m_post_processing_delay_min_wait,
                                            m_post_processing_delay_max_wait,
-                                           m_postprocess_state,
-                                           m_postprocess_state_mutex };
+                                           m_postprocess_state };
 
   const auto wait_data = [this]() -> folly::coro::Task<void> {
     // folly::coro::timeout cancels the task on timeout.

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -137,7 +137,10 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const appfwk::DAQModule::Comma
   m_num_lb_insert_failures = 0;
   m_stats_packet_count = 0;
   m_rawq_timeout_count = 0;
-  m_num_post_processing_delay_max_waits = 0;
+  m_num_postprocess_schedule_timeouts = 0;
+  m_num_postprocess_late_arrivals = 0;
+  m_postprocess_lateness_from_last_processed = 0;
+  m_postprocess_lateness_from_newest = 0;
 
   m_t0 = std::chrono::high_resolution_clock::now();
 
@@ -219,7 +222,10 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
   ri.set_num_lb_insert_failures(local_num_lb_insert_failures);
   ri.set_sum_requests(m_sum_requests.load());
   ri.set_num_requests(m_num_requests.exchange(0));
-  ri.set_num_post_processing_delay_max_waits(m_num_post_processing_delay_max_waits.exchange(0));
+  ri.set_num_postprocess_schedule_timeouts(m_num_postprocess_schedule_timeouts.exchange(0));
+  ri.set_num_postprocess_late_arrivals(m_num_postprocess_late_arrivals.load());
+  ri.set_postprocess_lateness_from_last_processed(m_postprocess_lateness_from_last_processed.load());
+  ri.set_postprocess_lateness_from_newest(m_postprocess_lateness_from_newest.load());
   ri.set_last_daq_timestamp(m_raw_processor_impl->get_last_daq_time());
   ri.set_newest_timestamp(m_raw_processor_impl->get_last_daq_time());
   ri.set_oldest_timestamp(m_request_handler_impl->get_oldest_time());
@@ -253,22 +259,43 @@ void
 DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT&& payload)
 {
   m_raw_processor_impl->preprocess_item(&payload);
+
+  auto payload_ts = payload.get_timestamp();
+
   if (m_request_handler_supports_cutoff_timestamp) {
-    int64_t diff1 = payload.get_timestamp() - m_request_handler_impl->get_cutoff_timestamp();
+    int64_t diff1 = payload_ts - m_request_handler_impl->get_cutoff_timestamp();
     if (diff1 <= 0) {
       // m_request_handler_impl->increment_tardy_tp_count();
       ers::warning(DataPacketArrivedTooLate(ERS_HERE,
                                             m_sourceid,
                                             m_run_number,
-                                            payload.get_timestamp(),
+                                            payload_ts,
                                             m_request_handler_impl->get_cutoff_timestamp(),
                                             diff1,
                                             (static_cast<double>(diff1) / 62500.0)));
     }
   }
+
+  if (m_processing_delay_ticks > 0) {
+    timestamp_t next_window_start_ts;
+    timestamp_t last_processed_ts;
+
+    {
+      std::lock_guard<std::mutex> lock(m_postprocess_state_mutex);
+      next_window_start_ts = m_postprocess_state.next_window_start_ts;
+      last_processed_ts = m_postprocess_state.last_processed_ts;
+    }
+
+    if (payload_ts < next_window_start_ts) {
+      ++m_num_postprocess_late_arrivals;
+      m_postprocess_lateness_from_last_processed.store(last_processed_ts - payload_ts);
+      m_postprocess_lateness_from_newest.store(m_latency_buffer_impl->back()->get_timestamp() - payload_ts);
+    }
+  }
+
   if (!m_latency_buffer_impl->write(std::move(payload))) {
     // TLOG_DEBUG(TLVL_TAKE_NOTE) << "***ERROR: Latency buffer insert failed! (Payload timestamp=" <<
-    // payload.get_timestamp() << ")";
+    // payload_ts << ")";
     m_num_lb_insert_failures++;
     return;
   }
@@ -300,7 +327,10 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
   m_num_payloads = 0;
   m_sum_payloads = 0;
   m_stats_packet_count = 0;
-  m_num_post_processing_delay_max_waits = 0;
+  m_num_postprocess_schedule_timeouts = 0;
+  m_num_postprocess_late_arrivals = 0;
+  m_postprocess_lateness_from_last_processed = 0;
+  m_postprocess_lateness_from_newest = 0;  
 
   while (m_run_marker.load()) {
     // Try to acquire data
@@ -332,7 +362,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule()
                                            *m_raw_processor_impl,
                                            m_processing_delay_ticks,
                                            m_post_processing_delay_min_wait,
-                                           m_post_processing_delay_max_wait };
+                                           m_post_processing_delay_max_wait,
+                                           m_postprocess_state,
+                                           m_postprocess_state_mutex };
 
   const auto wait_data = [this]() -> folly::coro::Task<void> {
     // folly::coro::timeout cancels the task on timeout.
@@ -352,7 +384,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule()
 
       } catch (const folly::FutureTimeout&) {
         timeout = true;
-        ++m_num_post_processing_delay_max_waits;
+        ++m_num_postprocess_schedule_timeouts;
       }
     } else {
       co_await m_baton;

--- a/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
+++ b/include/datahandlinglibs/models/detail/DataHandlingModel.hxx
@@ -140,9 +140,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const appfwk::DAQModule::Comma
   m_rawq_timeout_count = 0;
   m_num_postprocess_schedule_timeouts = 0;
   m_num_postprocess_late_arrivals = 0;
-  m_max_postprocess_tick_diff_to_next_window_start = 0;
-  m_max_postprocess_tick_distance_to_newest = 0;
-  m_max_postprocess_tick_diff_to_last_processed = 0;
+  m_max_postprocess_tick_diff_to_next_window_start = std::numeric_limits<max_postprocess_tick_diff_to_next_window_start_t>::min();
+  m_max_postprocess_tick_diff_to_newest = std::numeric_limits<max_postprocess_tick_diff_to_newest_t>::min();
+  m_max_postprocess_tick_diff_to_last_processed = std::numeric_limits<max_postprocess_tick_diff_to_last_processed_t>::min();
 
   m_t0 = std::chrono::high_resolution_clock::now();
 
@@ -226,9 +226,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
   ri.set_num_requests(m_num_requests.exchange(0));
   ri.set_num_postprocess_schedule_timeouts(m_num_postprocess_schedule_timeouts.exchange(0));
   ri.set_num_postprocess_late_arrivals(m_num_postprocess_late_arrivals.load());
-  ri.set_max_postprocess_tick_diff_to_next_window_start(m_max_postprocess_tick_diff_to_next_window_start.exchange(0));
-  ri.set_max_postprocess_tick_distance_to_newest(m_max_postprocess_tick_distance_to_newest.exchange(0));
-  ri.set_max_postprocess_tick_diff_to_last_processed(m_max_postprocess_tick_diff_to_last_processed.exchange(0));
+  ri.set_max_postprocess_tick_diff_to_next_window_start(m_max_postprocess_tick_diff_to_next_window_start.exchange(std::numeric_limits<max_postprocess_tick_diff_to_next_window_start_t>::min()));
+  ri.set_max_postprocess_tick_diff_to_newest(m_max_postprocess_tick_diff_to_newest.exchange(std::numeric_limits<max_postprocess_tick_diff_to_newest_t>::min()));
+  ri.set_max_postprocess_tick_diff_to_last_processed(m_max_postprocess_tick_diff_to_last_processed.exchange(std::numeric_limits<max_postprocess_tick_diff_to_last_processed_t>::min()));
   ri.set_last_daq_timestamp(m_raw_processor_impl->get_last_daq_time());
   ri.set_newest_timestamp(m_raw_processor_impl->get_last_daq_time());
   ri.set_oldest_timestamp(m_request_handler_impl->get_oldest_time());
@@ -279,7 +279,7 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT&& payload)
     }
   }
 
-  if (m_processing_delay_ticks > 0) {
+  if (m_processing_delay_ticks > 0 && m_latency_buffer_impl->occupancy() != 0) {
     // May not belong to the same state but we accept this possibility of inconsistency
     auto next_window_start_ts = m_postprocess_state.next_window_start_ts.load(std::memory_order_relaxed);
     auto last_processed_ts = m_postprocess_state.last_processed_ts.load(std::memory_order_relaxed);
@@ -291,21 +291,24 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT&& payload)
     }
 
     if (is_late_arrival || !m_post_processing_delay_monitor_late_tick_diffs_only) {
+      auto payload_ts_signed = static_cast<int64_t>(payload_ts);
+
       auto diff_to_next_window_start =
-        static_cast<int64_t>(next_window_start_ts) - static_cast<int64_t>(payload_ts);
+        static_cast<int64_t>(next_window_start_ts) - payload_ts_signed;
 
       if (diff_to_next_window_start > m_max_postprocess_tick_diff_to_next_window_start.load()) {
         m_max_postprocess_tick_diff_to_next_window_start.store(diff_to_next_window_start);
       }      
 
-      auto distance_to_newest = m_latency_buffer_impl->back()->get_timestamp() - payload_ts;
+      auto diff_to_newest = 
+        static_cast<int64_t>(m_latency_buffer_impl->back()->get_timestamp()) - payload_ts_signed;
 
-      if (distance_to_newest > m_max_postprocess_tick_distance_to_newest.load()) {
-        m_max_postprocess_tick_distance_to_newest.store(distance_to_newest);
+      if (diff_to_newest > m_max_postprocess_tick_diff_to_newest.load()) {
+        m_max_postprocess_tick_diff_to_newest.store(diff_to_newest);
       }
 
       auto diff_to_last_processed =
-        static_cast<int64_t>(last_processed_ts) - static_cast<int64_t>(payload_ts);
+        static_cast<int64_t>(last_processed_ts) - payload_ts_signed;
       
       if (diff_to_last_processed > m_max_postprocess_tick_diff_to_last_processed.load()) {
         m_max_postprocess_tick_diff_to_last_processed.store(diff_to_last_processed);
@@ -349,9 +352,9 @@ DataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
   m_stats_packet_count = 0;
   m_num_postprocess_schedule_timeouts = 0;
   m_num_postprocess_late_arrivals = 0;
-  m_max_postprocess_tick_diff_to_next_window_start = 0;  
-  m_max_postprocess_tick_distance_to_newest = 0;  
-  m_max_postprocess_tick_diff_to_last_processed = 0;
+  m_max_postprocess_tick_diff_to_next_window_start = std::numeric_limits<max_postprocess_tick_diff_to_next_window_start_t>::min();
+  m_max_postprocess_tick_diff_to_newest = std::numeric_limits<max_postprocess_tick_diff_to_newest_t>::min();
+  m_max_postprocess_tick_diff_to_last_processed = std::numeric_limits<max_postprocess_tick_diff_to_last_processed_t>::min();
 
   while (m_run_marker.load()) {
     // Try to acquire data

--- a/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
+++ b/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
@@ -30,7 +30,21 @@ public:
     DataHandlingModel<ReadoutType, RequestHandlerType, LatencyBufferType, RawDataProcessorType, InputDataType>;
   using Base::Base;
   using Base::PostprocessScheduleAlgorithm;
-  using typename Base::num_post_processing_delay_max_waits_t;
+  using typename Base::num_postprocess_schedule_timeouts_t;
+  using typename Base::num_postprocess_late_arrivals_t;
+  using typename Base::postprocess_lateness_from_last_processed_t;
+  using typename Base::postprocess_lateness_from_newest_t;
+
+  void test_process_item(
+    std::shared_ptr<LatencyBufferType> latency_buffer_impl, std::shared_ptr<RawDataProcessorType> raw_processor_impl,
+    uint64_t processing_delay_ticks, ReadoutType&& payload) 
+  {
+    this->m_latency_buffer_impl = latency_buffer_impl;
+    this->m_raw_processor_impl = raw_processor_impl;
+    this->m_request_handler_supports_cutoff_timestamp = false;
+    this->m_processing_delay_ticks = processing_delay_ticks;
+    this->process_item(std::move(payload));
+  }
 
   void test_run_postprocess_scheduler(
     std::shared_ptr<LatencyBufferType> latency_buffer_impl, std::shared_ptr<RawDataProcessorType> raw_processor_impl,
@@ -43,15 +57,39 @@ public:
     this->run_postprocess_scheduler();
   }
 
-  num_post_processing_delay_max_waits_t get_num_post_processing_delay_max_waits()
+  num_postprocess_schedule_timeouts_t get_num_postprocess_schedule_timeouts()
   {
-    return this->m_num_post_processing_delay_max_waits.load();
+    return this->m_num_postprocess_schedule_timeouts.load();
   }
+
+  num_postprocess_late_arrivals_t get_num_postprocess_late_arrivals()
+  {
+    return this->m_num_postprocess_late_arrivals.load();
+  }  
+
+  postprocess_lateness_from_last_processed_t get_postprocess_lateness_from_last_processed()
+  {
+    return this->m_postprocess_lateness_from_last_processed.load();
+  }    
+
+  postprocess_lateness_from_newest_t get_postprocess_lateness_from_newest()
+  {
+    return this->m_postprocess_lateness_from_newest.load();
+  }    
 
   void set_run_marker(bool run_marker)
   {
     return this->m_run_marker.store(run_marker);
   }
+  
+  auto& get_postprocess_state() {
+    return this->m_postprocess_state;
+  }
+
+  auto& get_postprocess_state_mutex() {
+    return this->m_postprocess_state_mutex;
+  }
+
 };
 
 } // namespace unittest

--- a/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
+++ b/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
@@ -35,8 +35,9 @@ public:
   using Base::PostprocessScheduleAlgorithm;
   using typename Base::num_postprocess_schedule_timeouts_t;
   using typename Base::num_postprocess_late_arrivals_t;
-  using typename Base::postprocess_lateness_from_last_processed_t;
-  using typename Base::postprocess_lateness_from_newest_t;
+  using typename Base::max_postprocess_distance_from_next_window_start_t;
+  using typename Base::max_postprocess_distance_from_newest_t;
+  using typename Base::max_postprocess_distance_from_last_processed_t;
 
   void test_process_item(
     std::shared_ptr<LatencyBufferType> latency_buffer_impl, std::shared_ptr<RawDataProcessorType> raw_processor_impl,
@@ -70,15 +71,20 @@ public:
     return this->m_num_postprocess_late_arrivals.load();
   }  
 
-  postprocess_lateness_from_last_processed_t get_postprocess_lateness_from_last_processed()
+  max_postprocess_distance_from_next_window_start_t get_max_postprocess_distance_from_next_window_start()
   {
-    return this->m_postprocess_lateness_from_last_processed.load();
-  }    
+    return this->m_max_postprocess_distance_from_next_window_start.load();
+  }  
 
-  postprocess_lateness_from_newest_t get_postprocess_lateness_from_newest()
+  max_postprocess_distance_from_newest_t get_max_postprocess_distance_from_newest()
   {
-    return this->m_postprocess_lateness_from_newest.load();
-  }    
+    return this->m_max_postprocess_distance_from_newest.load();
+  }  
+  
+  max_postprocess_distance_from_last_processed_t get_max_postprocess_distance_from_last_processed()
+  {
+    return this->m_max_postprocess_distance_from_last_processed.load();
+  }      
 
   void set_run_marker(bool run_marker)
   {

--- a/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
+++ b/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
@@ -35,9 +35,9 @@ public:
   using Base::PostprocessScheduleAlgorithm;
   using typename Base::num_postprocess_schedule_timeouts_t;
   using typename Base::num_postprocess_late_arrivals_t;
-  using typename Base::max_postprocess_distance_from_next_window_start_t;
-  using typename Base::max_postprocess_distance_from_newest_t;
-  using typename Base::max_postprocess_distance_from_last_processed_t;
+  using typename Base::max_postprocess_tick_diff_to_next_window_start_t;
+  using typename Base::max_postprocess_tick_distance_to_newest_t;
+  using typename Base::max_postprocess_tick_diff_to_last_processed_t;
 
   void test_process_item(
     std::shared_ptr<LatencyBufferType> latency_buffer_impl, std::shared_ptr<RawDataProcessorType> raw_processor_impl,
@@ -71,19 +71,19 @@ public:
     return this->m_num_postprocess_late_arrivals.load();
   }  
 
-  max_postprocess_distance_from_next_window_start_t get_max_postprocess_distance_from_next_window_start()
+  max_postprocess_tick_diff_to_next_window_start_t get_max_postprocess_tick_diff_to_next_window_start()
   {
-    return this->m_max_postprocess_distance_from_next_window_start.load();
+    return this->m_max_postprocess_tick_diff_to_next_window_start.load();
   }  
 
-  max_postprocess_distance_from_newest_t get_max_postprocess_distance_from_newest()
+  max_postprocess_tick_distance_to_newest_t get_max_postprocess_tick_distance_to_newest()
   {
-    return this->m_max_postprocess_distance_from_newest.load();
+    return this->m_max_postprocess_tick_distance_to_newest.load();
   }  
   
-  max_postprocess_distance_from_last_processed_t get_max_postprocess_distance_from_last_processed()
+  max_postprocess_tick_diff_to_last_processed_t get_max_postprocess_tick_diff_to_last_processed()
   {
-    return this->m_max_postprocess_distance_from_last_processed.load();
+    return this->m_max_postprocess_tick_diff_to_last_processed.load();
   }      
 
   void set_run_marker(bool run_marker)

--- a/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
+++ b/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
@@ -52,12 +52,12 @@ public:
 
   void test_run_postprocess_scheduler(
     std::shared_ptr<LatencyBufferType> latency_buffer_impl, std::shared_ptr<RawDataProcessorType> raw_processor_impl,
-    std::unique_ptr<folly::Timekeeper> timekeeper, uint64_t post_processing_delay_max_wait) // NOLINT(build/unsigned)
+    std::unique_ptr<folly::Timekeeper> timekeeper, uint64_t post_processing_delay_max_wait_ms) // NOLINT(build/unsigned)
   {
     this->m_latency_buffer_impl = latency_buffer_impl;
     this->m_raw_processor_impl = raw_processor_impl;
     this->m_timekeeper = std::move(timekeeper);
-    this->m_post_processing_delay_max_wait = post_processing_delay_max_wait;
+    this->m_post_processing_delay_max_wait_ms = post_processing_delay_max_wait_ms;
     this->run_postprocess_scheduler();
   }
 

--- a/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
+++ b/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
@@ -86,10 +86,6 @@ public:
     return this->m_postprocess_state;
   }
 
-  auto& get_postprocess_state_mutex() {
-    return this->m_postprocess_state_mutex;
-  }
-
 };
 
 } // namespace unittest

--- a/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
+++ b/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
@@ -36,7 +36,7 @@ public:
   using typename Base::num_postprocess_schedule_timeouts_t;
   using typename Base::num_postprocess_late_arrivals_t;
   using typename Base::max_postprocess_tick_diff_to_next_window_start_t;
-  using typename Base::max_postprocess_tick_distance_to_newest_t;
+  using typename Base::max_postprocess_tick_diff_to_newest_t;
   using typename Base::max_postprocess_tick_diff_to_last_processed_t;
 
   void test_process_item(
@@ -76,9 +76,9 @@ public:
     return this->m_max_postprocess_tick_diff_to_next_window_start.load();
   }  
 
-  max_postprocess_tick_distance_to_newest_t get_max_postprocess_tick_distance_to_newest()
+  max_postprocess_tick_diff_to_newest_t get_max_postprocess_tick_diff_to_newest()
   {
-    return this->m_max_postprocess_tick_distance_to_newest.load();
+    return this->m_max_postprocess_tick_diff_to_newest.load();
   }  
   
   max_postprocess_tick_diff_to_last_processed_t get_max_postprocess_tick_diff_to_last_processed()

--- a/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
+++ b/include/datahandlinglibs/testutils/UnitTestUtilities.hpp
@@ -6,12 +6,15 @@
  * received with this code.
  */
 
-#ifndef DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_TESTUTILS_UNITTESTUTILITIES_HPP
-#define DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_TESTUTILS_UNITTESTUTILITIES_HPP
+#ifndef DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_TESTUTILS_UNITTESTUTILITIES_HPP_
+#define DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_TESTUTILS_UNITTESTUTILITIES_HPP_
 
 #include "datahandlinglibs/models/DataHandlingModel.hpp"
 #include "datahandlinglibs/models/DefaultRequestHandlerModel.hpp"
 #include "datahandlinglibs/models/TaskRawDataProcessorModel.hpp"
+
+#include <memory>
+#include <utility>
 
 namespace dunedaq {
 namespace datahandlinglibs {
@@ -37,7 +40,7 @@ public:
 
   void test_process_item(
     std::shared_ptr<LatencyBufferType> latency_buffer_impl, std::shared_ptr<RawDataProcessorType> raw_processor_impl,
-    uint64_t processing_delay_ticks, ReadoutType&& payload) 
+    uint64_t processing_delay_ticks, ReadoutType&& payload) // NOLINT(build/unsigned)
   {
     this->m_latency_buffer_impl = latency_buffer_impl;
     this->m_raw_processor_impl = raw_processor_impl;
@@ -48,7 +51,7 @@ public:
 
   void test_run_postprocess_scheduler(
     std::shared_ptr<LatencyBufferType> latency_buffer_impl, std::shared_ptr<RawDataProcessorType> raw_processor_impl,
-    std::unique_ptr<folly::Timekeeper> timekeeper, uint64_t post_processing_delay_max_wait)
+    std::unique_ptr<folly::Timekeeper> timekeeper, uint64_t post_processing_delay_max_wait) // NOLINT(build/unsigned)
   {
     this->m_latency_buffer_impl = latency_buffer_impl;
     this->m_raw_processor_impl = raw_processor_impl;
@@ -92,4 +95,4 @@ public:
 } // namespace datahandlinglibs
 } // namespace dunedaq
 
-#endif // DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_TESTUTILS_UNITTESTUTILITIES_HPP
+#endif // DATAHANDLINGLIBS_INCLUDE_DATAHANDLINGLIBS_TESTUTILS_UNITTESTUTILITIES_HPP_

--- a/schema/datahandlinglibs/opmon/datahandling_info.proto
+++ b/schema/datahandlinglibs/opmon/datahandling_info.proto
@@ -23,7 +23,10 @@ message DataHandlerInfo {
   uint64 last_daq_timestamp = 21; // Most recent DAQ timestamp processed 
   uint64 newest_timestamp = 22; // Most recent DAQ timestamp processed 
   uint64 oldest_timestamp = 23; // Most recent DAQ timestamp processed 
-  uint64 num_post_processing_delay_max_waits = 31; // Number of times post-processing was triggered due to max wait time elapsing before data arrival
+  uint64 num_postprocess_schedule_timeouts = 31; // Number of times post-processing was triggered due to max wait time elapsing before data arrival
+  uint64 num_postprocess_late_arrivals = 32; // Number of data arrivals for an already closed post-processing window
+  uint64 postprocess_lateness_from_last_processed = 33; // Tick difference between late arrival and the last processed item
+  uint64 postprocess_lateness_from_newest = 34; // Tick difference between late arrival and the newest item in the buffer
 }
 
 message RequestHandlerInfo {

--- a/schema/datahandlinglibs/opmon/datahandling_info.proto
+++ b/schema/datahandlinglibs/opmon/datahandling_info.proto
@@ -25,7 +25,7 @@ message DataHandlerInfo {
   uint64 oldest_timestamp = 23; // Most recent DAQ timestamp processed 
   uint64 num_postprocess_schedule_timeouts = 31; // Number of times post-processing was triggered due to max wait time elapsing before data arrival
   uint64 num_postprocess_late_arrivals = 32; // Number of data arrivals for an already closed post-processing window
-  uint64 max_postprocess_tick_distance_to_newest = 33; // Maximum tick difference between late arrival and the newest item in the buffer since last monitoring
+  int64 max_postprocess_tick_diff_to_newest = 33; // Maximum tick difference between late arrival and the newest item in the buffer since last monitoring
   int64 max_postprocess_tick_diff_to_next_window_start = 34; // Maximum tick difference between late arrival and the next processing window start since last monitoring
   int64 max_postprocess_tick_diff_to_last_processed = 35; // Maximum tick difference between late arrival and the last processed item since last monitoring
 }

--- a/schema/datahandlinglibs/opmon/datahandling_info.proto
+++ b/schema/datahandlinglibs/opmon/datahandling_info.proto
@@ -25,8 +25,9 @@ message DataHandlerInfo {
   uint64 oldest_timestamp = 23; // Most recent DAQ timestamp processed 
   uint64 num_postprocess_schedule_timeouts = 31; // Number of times post-processing was triggered due to max wait time elapsing before data arrival
   uint64 num_postprocess_late_arrivals = 32; // Number of data arrivals for an already closed post-processing window
-  uint64 postprocess_lateness_from_last_processed = 33; // Tick difference between late arrival and the last processed item
-  uint64 postprocess_lateness_from_newest = 34; // Tick difference between late arrival and the newest item in the buffer
+  uint64 max_postprocess_distance_from_newest = 33; // Maximum tick difference between late arrival and the newest item in the buffer since last monitoring
+  uint64 max_postprocess_distance_from_next_window_start = 34; // Maximum tick difference between late arrival and the next processing window start since last monitoring
+  uint64 max_postprocess_distance_from_last_processed = 35; // Maximum tick difference between late arrival and the last processed item since last monitoring
 }
 
 message RequestHandlerInfo {

--- a/schema/datahandlinglibs/opmon/datahandling_info.proto
+++ b/schema/datahandlinglibs/opmon/datahandling_info.proto
@@ -25,9 +25,9 @@ message DataHandlerInfo {
   uint64 oldest_timestamp = 23; // Most recent DAQ timestamp processed 
   uint64 num_postprocess_schedule_timeouts = 31; // Number of times post-processing was triggered due to max wait time elapsing before data arrival
   uint64 num_postprocess_late_arrivals = 32; // Number of data arrivals for an already closed post-processing window
-  uint64 max_postprocess_distance_from_newest = 33; // Maximum tick difference between late arrival and the newest item in the buffer since last monitoring
-  uint64 max_postprocess_distance_from_next_window_start = 34; // Maximum tick difference between late arrival and the next processing window start since last monitoring
-  uint64 max_postprocess_distance_from_last_processed = 35; // Maximum tick difference between late arrival and the last processed item since last monitoring
+  uint64 max_postprocess_tick_distance_to_newest = 33; // Maximum tick difference between late arrival and the newest item in the buffer since last monitoring
+  int64 max_postprocess_tick_diff_to_next_window_start = 34; // Maximum tick difference between late arrival and the next processing window start since last monitoring
+  int64 max_postprocess_tick_diff_to_last_processed = 35; // Maximum tick difference between late arrival and the last processed item since last monitoring
 }
 
 message RequestHandlerInfo {

--- a/unittest/datahandlinglibs_DataHandlingModel_test.cxx
+++ b/unittest/datahandlinglibs_DataHandlingModel_test.cxx
@@ -63,13 +63,12 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
     buffer->write(std::move(frame));
     model.test_process_item(buffer, raw_processor, delay_ticks, std::move(frame));
   }
-  // Buffer = {1, 3, 4}  
-  
+  // Buffer = {1, 3, 4}
+
+  // First pass
   bool timeout = false;
-  // Just populating `m_timeout_counts`
-  sched_algo.run(timeout);
-  sched_algo.run(timeout);
-  sched_algo.run(timeout);
+  int processed_count = sched_algo.run(timeout);
+  BOOST_REQUIRE_EQUAL(processed_count, 0);
 
   // Buffer = {1, 3, 4} delay_ticks = 4
   timeout = true;
@@ -77,7 +76,7 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
   // 4 - -1 > 4 -> postprocess {1}
   // 3 - 1 * 2
   // 4 - 1 <= 4 -> no postprocessing
-  int processed_count = sched_algo.run(timeout);
+  processed_count += sched_algo.run(timeout);
   BOOST_REQUIRE_EQUAL(processed_count, 1);
 
   // 2nd timeout => 3 - 2 * 2 (delay_max_wait = 2)
@@ -180,15 +179,7 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
   // First pass
   bool timeout = false;
   int processed_count = sched_algo.run(timeout);
-  // Buffer = {1, 2, 3, 4, 5} delay_ticks = 4
-  // 5 - 1 > 4 is false => no postprocessing
   BOOST_REQUIRE_EQUAL(processed_count, 0);
-
-  // Just populating `m_timeout_counts`
-  sched_algo.run(timeout);
-  sched_algo.run(timeout);
-  sched_algo.run(timeout);
-  sched_algo.run(timeout);
 
   timeout = true;
   // 1st timeout => timeout_accumulated = 1 * 2 (delay_max_wait = 2)
@@ -250,14 +241,13 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
     *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait, model.get_postprocess_state(), model.get_postprocess_state_mutex()
   };
 
+  // First pass
   bool timeout = false;
-  // Just populating `m_timeout_counts`
-  sched_algo.run(timeout);
-  sched_algo.run(timeout);
-  sched_algo.run(timeout);
+  int processed_count = sched_algo.run(timeout);
+  BOOST_REQUIRE_EQUAL(processed_count, 0);  
 
   timeout = true;
-  int processed_count = sched_algo.run(timeout);
+  processed_count = sched_algo.run(timeout);
   // Buffer = {1, 2, 4} delay_ticks = 1
   // 1st timeout => timeout_accumulated = 1 * 2 (delay_max_wait = 2)
   // ts_window_end = 4 - 1 + 2 => postprocess until 5 {1, 2, 4}

--- a/unittest/datahandlinglibs_DataHandlingModel_test.cxx
+++ b/unittest/datahandlinglibs_DataHandlingModel_test.cxx
@@ -88,16 +88,17 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
 
   auto last_processed_ts = 3 * 62500;
   auto newest_ts = 4 * 62500;
-  // m_next_window_start = {4}
+  auto next_window_start_ts = 4 * 62500;
 
   // Data arrived for a closed processing window
   {
     ReadoutType frame{};
     frame.timestamp = 2 * 62500;
     model.test_process_item(buffer, raw_processor, delay_ticks, std::move(frame));
-    BOOST_REQUIRE_EQUAL(model.get_num_postprocess_late_arrivals(), 1);  
-    BOOST_REQUIRE_EQUAL(model.get_postprocess_lateness_from_last_processed(), last_processed_ts - frame.timestamp);  
-    BOOST_REQUIRE_EQUAL(model.get_postprocess_lateness_from_newest(), newest_ts - frame.timestamp);  
+    BOOST_REQUIRE_EQUAL(model.get_num_postprocess_late_arrivals(), 1);
+    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_distance_from_next_window_start(), next_window_start_ts - frame.timestamp);  
+    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_distance_from_newest(), newest_ts - frame.timestamp);  
+    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_distance_from_last_processed(), last_processed_ts - frame.timestamp);  
   }
 
 }

--- a/unittest/datahandlinglibs_DataHandlingModel_test.cxx
+++ b/unittest/datahandlinglibs_DataHandlingModel_test.cxx
@@ -25,6 +25,84 @@ using namespace dunedaq::datahandlinglibs;
 
 using ReadoutType = types::DUMMY_FRAME_STRUCT;
 
+BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgorithm_data_arrives_after_window_processed_with_timeout_monitoring)
+{
+  std::atomic<bool> run_marker = true;
+
+  auto model =
+    unittest::MockDataHandlingModel<ReadoutType,
+                                    DefaultRequestHandlerModel<ReadoutType, SkipListLatencyBufferModel<ReadoutType>>,
+                                    SkipListLatencyBufferModel<ReadoutType>,
+                                    TaskRawDataProcessorModel<ReadoutType>>(run_marker);
+
+  auto buffer = std::make_shared<SkipListLatencyBufferModel<ReadoutType>>();
+
+  constexpr bool post_processing_enabled = true;
+  auto error_registry = std::make_unique<FrameErrorRegistry>();
+
+  auto raw_processor =
+    std::make_shared<TaskRawDataProcessorModel<ReadoutType>>(error_registry, post_processing_enabled);
+
+  constexpr uint64_t delay_ticks = 4 * 62500; // NOLINT(build/unsigned)
+  constexpr uint64_t delay_min_wait = 1; // NOLINT(build/unsigned)
+  constexpr uint64_t delay_max_wait = 2; // NOLINT(build/unsigned)
+
+  typename decltype(model)::PostprocessScheduleAlgorithm sched_algo{
+    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait, model.get_postprocess_state(), model.get_postprocess_state_mutex()
+  };  
+
+  {
+    ReadoutType frame{};
+    frame.timestamp = 1 * 62500;
+    buffer->write(std::move(frame));  
+    model.test_process_item(buffer, raw_processor, delay_ticks, std::move(frame));
+  }
+  for (int i = 3; i < 5; i++) {
+    ReadoutType frame{};
+    frame.timestamp = i * 62500;
+    buffer->write(std::move(frame));
+    model.test_process_item(buffer, raw_processor, delay_ticks, std::move(frame));
+  }
+  // Buffer = {1, 3, 4}  
+  
+  bool timeout = false;
+  // Just populating `m_timeout_counts`
+  sched_algo.run(timeout);
+  sched_algo.run(timeout);
+  sched_algo.run(timeout);
+
+  // Buffer = {1, 3, 4} delay_ticks = 4
+  timeout = true;
+  // 1st timeout => 1 - 1 * 2 (delay_max_wait = 2)
+  // 4 - -1 > 4 -> postprocess {1}
+  // 3 - 1 * 2
+  // 4 - 1 <= 4 -> no postprocessing
+  int processed_count = sched_algo.run(timeout);
+  BOOST_REQUIRE_EQUAL(processed_count, 1);
+
+  // 2nd timeout => 3 - 2 * 2 (delay_max_wait = 2)
+  // 4 - -1 > 4 -> postprocess {3}
+  // 4 - 2 * 2
+  // 4 - 0 <= 4 -> no postprocessing
+  processed_count += sched_algo.run(timeout);
+  BOOST_REQUIRE_EQUAL(processed_count, 2);
+
+  auto last_processed_ts = 3 * 62500;
+  auto newest_ts = 4 * 62500;
+  // m_next_window_start = {4}
+
+  // Data arrived for a closed processing window
+  {
+    ReadoutType frame{};
+    frame.timestamp = 2 * 62500;
+    model.test_process_item(buffer, raw_processor, delay_ticks, std::move(frame));
+    BOOST_REQUIRE_EQUAL(model.get_num_postprocess_late_arrivals(), 1);  
+    BOOST_REQUIRE_EQUAL(model.get_postprocess_lateness_from_last_processed(), last_processed_ts - frame.timestamp);  
+    BOOST_REQUIRE_EQUAL(model.get_postprocess_lateness_from_newest(), newest_ts - frame.timestamp);  
+  }
+
+}
+
 BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_run_postprocess_scheduler_timeout)
 {
   std::atomic<bool> run_marker = true;
@@ -64,7 +142,7 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_run_postprocess_schedule
   model.set_run_marker(false); // Let coroutine end
   coro_thread.join(); // The test will stuck here if timeout is not triggered (because of folly::coro::blockingWait)
 
-  BOOST_REQUIRE_EQUAL(model.get_num_post_processing_delay_max_waits(), 1);
+  BOOST_REQUIRE_EQUAL(model.get_num_postprocess_schedule_timeouts(), 1);
 }
 
 BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgorithm_timeout)
@@ -96,7 +174,7 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
   constexpr uint64_t delay_max_wait = 2; // NOLINT(build/unsigned)
 
   typename decltype(model)::PostprocessScheduleAlgorithm sched_algo{
-    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait
+    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait, model.get_postprocess_state(), model.get_postprocess_state_mutex()
   };
 
   // First pass
@@ -106,19 +184,25 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
   // 5 - 1 > 4 is false => no postprocessing
   BOOST_REQUIRE_EQUAL(processed_count, 0);
 
+  // Just populating `m_timeout_counts`
+  sched_algo.run(timeout);
+  sched_algo.run(timeout);
+  sched_algo.run(timeout);
+  sched_algo.run(timeout);
+
   timeout = true;
   // 1st timeout => timeout_accumulated = 1 * 2 (delay_max_wait = 2)
-  // end_win_ts = 5 - 4 + 2 => postprocess until 3 {1, 2}
+  // ts_window_end = 5 - 4 + 2 => postprocess until 3 {1, 2}
   processed_count += sched_algo.run(timeout);
   BOOST_REQUIRE_EQUAL(processed_count, 2);
 
   // 2nd timeout => timeout_accumulated = 2 * 2
-  // end_win_ts = 5 - 4 + 4 => postprocess until 5 {3, 4}
+  // ts_window_end = 5 - 4 + 4 => postprocess until 5 {3, 4}
   processed_count += sched_algo.run(timeout);
   BOOST_REQUIRE_EQUAL(processed_count, 4);
 
   // 3rd timeout => timeout_accumulated = 3 * 2
-  // end_win_ts = 5 - 4 + 6 => postprocess until 6 (capped to newest_ts + 1) {5}
+  // ts_window_end = 5 - 4 + 6 => postprocess until 6 (capped to newest_ts + 1) {5}
   processed_count += sched_algo.run(timeout);
   BOOST_REQUIRE_EQUAL(processed_count, 5);
 
@@ -163,14 +247,20 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
   constexpr uint64_t delay_max_wait = 2; // NOLINT(build/unsigned)
 
   typename decltype(model)::PostprocessScheduleAlgorithm sched_algo{
-    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait
+    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait, model.get_postprocess_state(), model.get_postprocess_state_mutex()
   };
 
-  bool timeout = true;
+  bool timeout = false;
+  // Just populating `m_timeout_counts`
+  sched_algo.run(timeout);
+  sched_algo.run(timeout);
+  sched_algo.run(timeout);
+
+  timeout = true;
   int processed_count = sched_algo.run(timeout);
   // Buffer = {1, 2, 4} delay_ticks = 1
   // 1st timeout => timeout_accumulated = 1 * 2 (delay_max_wait = 2)
-  // end_win_ts = 4 - 1 + 2 => postprocess until 5 {1, 2, 4}
+  // ts_window_end = 4 - 1 + 2 => postprocess until 5 {1, 2, 4}
   BOOST_REQUIRE_EQUAL(processed_count, 3);
 
   {

--- a/unittest/datahandlinglibs_DataHandlingModel_test.cxx
+++ b/unittest/datahandlinglibs_DataHandlingModel_test.cxx
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
     model.test_process_item(buffer, raw_processor, delay_ticks, std::move(frame));
     BOOST_REQUIRE_EQUAL(model.get_num_postprocess_late_arrivals(), 1);
     BOOST_REQUIRE_EQUAL(model.get_max_postprocess_tick_diff_to_next_window_start(), next_window_start_ts - frame.timestamp);  
-    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_tick_distance_to_newest(), newest_ts - frame.timestamp);  
+    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_tick_diff_to_newest(), newest_ts - frame.timestamp);  
     BOOST_REQUIRE_EQUAL(model.get_max_postprocess_tick_diff_to_last_processed(), last_processed_ts - frame.timestamp);  
   }
 

--- a/unittest/datahandlinglibs_DataHandlingModel_test.cxx
+++ b/unittest/datahandlinglibs_DataHandlingModel_test.cxx
@@ -96,9 +96,9 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
     frame.timestamp = 2 * 62500;
     model.test_process_item(buffer, raw_processor, delay_ticks, std::move(frame));
     BOOST_REQUIRE_EQUAL(model.get_num_postprocess_late_arrivals(), 1);
-    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_distance_from_next_window_start(), next_window_start_ts - frame.timestamp);  
-    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_distance_from_newest(), newest_ts - frame.timestamp);  
-    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_distance_from_last_processed(), last_processed_ts - frame.timestamp);  
+    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_tick_diff_to_next_window_start(), next_window_start_ts - frame.timestamp);  
+    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_tick_distance_to_newest(), newest_ts - frame.timestamp);  
+    BOOST_REQUIRE_EQUAL(model.get_max_postprocess_tick_diff_to_last_processed(), last_processed_ts - frame.timestamp);  
   }
 
 }

--- a/unittest/datahandlinglibs_DataHandlingModel_test.cxx
+++ b/unittest/datahandlinglibs_DataHandlingModel_test.cxx
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
   constexpr uint64_t delay_max_wait = 2; // NOLINT(build/unsigned)
 
   typename decltype(model)::PostprocessScheduleAlgorithm sched_algo{
-    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait, model.get_postprocess_state(), model.get_postprocess_state_mutex()
+    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait, model.get_postprocess_state()
   };  
 
   {
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
   constexpr uint64_t delay_max_wait = 2; // NOLINT(build/unsigned)
 
   typename decltype(model)::PostprocessScheduleAlgorithm sched_algo{
-    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait, model.get_postprocess_state(), model.get_postprocess_state_mutex()
+    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait, model.get_postprocess_state()
   };
 
   // First pass
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
   constexpr uint64_t delay_max_wait = 2; // NOLINT(build/unsigned)
 
   typename decltype(model)::PostprocessScheduleAlgorithm sched_algo{
-    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait, model.get_postprocess_state(), model.get_postprocess_state_mutex()
+    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait, model.get_postprocess_state()
   };
 
   // First pass

--- a/unittest/datahandlinglibs_DataHandlingModel_test.cxx
+++ b/unittest/datahandlinglibs_DataHandlingModel_test.cxx
@@ -16,92 +16,175 @@
 
 #include <folly/futures/ManualTimekeeper.h>
 
+#include <chrono>
 #include <memory>
+#include <thread>
 #include <utility>
-
-BOOST_AUTO_TEST_SUITE(datahandlinglibs_DataHandlingModel_test)
+#include <vector>
 
 using namespace dunedaq::datahandlinglibs;
 
 using ReadoutType = types::DUMMY_FRAME_STRUCT;
+using SkipListLatencyBuffer = SkipListLatencyBufferModel<ReadoutType>;
+using DefaultRequestHandler = DefaultRequestHandlerModel<ReadoutType, SkipListLatencyBuffer>;
+
+/*
+ * Test Fixtures:
+ * - DataHandlingFixture: Full model testing
+ * - PostprocessScheduleAlgorithmFixture: Algorithm-only testing (call setup() before run())
+ * 
+ * Both fixtures start with empty buffers. Use setup()/add_frames()/add_frame() to populate.
+ */
+
+template<class RequestHandlerType, class LatencyBufferType>
+struct DataHandlingBaseFixture
+{
+  using RawDataProcessorType = TaskRawDataProcessorModel<ReadoutType>;
+  using ModelType =
+    unittest::MockDataHandlingModel<ReadoutType, RequestHandlerType, LatencyBufferType, RawDataProcessorType>;
+
+  static constexpr bool post_processing_enabled = true;
+
+  std::shared_ptr<LatencyBufferType> buffer;
+  std::unique_ptr<FrameErrorRegistry> error_registry;
+  std::shared_ptr<RawDataProcessorType> processor;
+
+protected:
+  DataHandlingBaseFixture()
+  {
+    buffer = std::make_shared<LatencyBufferType>();
+    error_registry = std::make_unique<FrameErrorRegistry>();
+    processor = std::make_shared<RawDataProcessorType>(error_registry, post_processing_enabled);
+  }
+
+public:
+  void setup(const std::vector<uint64_t>& timestamps = {}) // NOLINT(build/unsigned)
+  {
+    buffer->flush();
+    add_frames(timestamps);
+  }
+
+  void add_frame(uint64_t timestamp) // NOLINT(build/unsigned)
+  {
+    ReadoutType frame{};
+    frame.timestamp = timestamp;
+    buffer->write(std::move(frame));
+  }
+
+  void add_frames(const std::vector<uint64_t>& timestamps) // NOLINT(build/unsigned)
+  {
+    for (uint64_t ts : timestamps) { // NOLINT(build/unsigned)
+      add_frame(ts);
+    }
+  }
+};
+
+template<class RequestHandlerType, class LatencyBufferType>
+struct DataHandlingFixture : DataHandlingBaseFixture<RequestHandlerType, LatencyBufferType>
+{
+  using Base = DataHandlingBaseFixture<RequestHandlerType, LatencyBufferType>;
+  using RawDataProcessorType = typename Base::RawDataProcessorType;
+  using ModelType = typename Base::ModelType;
+
+  std::atomic<bool> run_marker = true;
+  std::unique_ptr<ModelType> model;
+
+  DataHandlingFixture() { model = std::make_unique<ModelType>(run_marker); }
+
+  void set_run_marker(bool run_marker) { model->set_run_marker(run_marker); }
+
+  void test_run_postprocess_scheduler(std::shared_ptr<LatencyBufferType> latency_buffer_impl,
+                                      std::shared_ptr<RawDataProcessorType> raw_processor_impl,
+                                      std::unique_ptr<folly::Timekeeper> timekeeper,
+                                      uint64_t post_processing_delay_max_wait) // NOLINT(build/unsigned)
+  {
+    model->test_run_postprocess_scheduler(
+      latency_buffer_impl, raw_processor_impl, std::move(timekeeper), post_processing_delay_max_wait);
+  }
+
+  ModelType::num_post_processing_delay_max_waits_t get_num_post_processing_delay_max_waits()
+  {
+    return model->get_num_post_processing_delay_max_waits();
+  }
+};
+
+struct PostprocessScheduleAlgorithmFixture : DataHandlingBaseFixture<DefaultRequestHandler, SkipListLatencyBuffer>
+{
+  using LatencyBufferType = SkipListLatencyBuffer;
+  using RequestHandlerType = DefaultRequestHandlerModel<ReadoutType, LatencyBufferType>;
+  using Base = DataHandlingBaseFixture<RequestHandlerType, LatencyBufferType>;
+  using AlgorithmType = typename Base::ModelType::PostprocessScheduleAlgorithm;
+
+  static constexpr uint64_t ms_to_ticks = 62500; // NOLINT(build/unsigned)
+
+  std::unique_ptr<AlgorithmType> algorithm;
+
+  void setup(uint64_t delay_ticks,                         // NOLINT(build/unsigned)
+             uint64_t delay_min_wait,                      // NOLINT(build/unsigned)
+             uint64_t delay_max_wait,                      // NOLINT(build/unsigned)
+             const std::vector<uint64_t>& timestamps = {}) // NOLINT(build/unsigned)
+  {
+    Base::setup(timestamps);
+    algorithm = std::make_unique<AlgorithmType>(*buffer, *processor, delay_ticks, delay_min_wait, delay_max_wait);
+  }
+
+  int run(bool timeout)
+  {
+    if (!algorithm) {
+      return 0;
+    }
+    return algorithm->run(timeout);
+  }
+};
+
+using DefaultDataHandlingFixture = DataHandlingFixture<DefaultRequestHandler, SkipListLatencyBuffer>;
+
+BOOST_FIXTURE_TEST_SUITE(datahandlinglibs_DataHandlingModel_test, DefaultDataHandlingFixture)
 
 BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_run_postprocess_scheduler_timeout)
 {
-  std::atomic<bool> run_marker = true;
-
-  auto model =
-    unittest::MockDataHandlingModel<ReadoutType,
-                                    DefaultRequestHandlerModel<ReadoutType, SkipListLatencyBufferModel<ReadoutType>>,
-                                    SkipListLatencyBufferModel<ReadoutType>,
-                                    TaskRawDataProcessorModel<ReadoutType>>(run_marker);
-
-  auto buffer = std::make_shared<SkipListLatencyBufferModel<ReadoutType>>(); // Empty buffer
-
-  constexpr bool post_processing_enabled = true;
-  auto error_registry = std::make_unique<FrameErrorRegistry>();
-
-  auto raw_processor =
-    std::make_shared<TaskRawDataProcessorModel<ReadoutType>>(error_registry, post_processing_enabled);
-
   auto timekeeper = std::make_unique<folly::ManualTimekeeper>();
   auto* timekeeper_ptr = timekeeper.get();
 
   constexpr uint64_t delay_max_wait = 2; // NOLINT(build/unsigned)
 
-  std::thread coro_thread([&]() {
-    model.test_run_postprocess_scheduler(buffer, raw_processor, std::move(timekeeper), delay_max_wait);
-  });
+  std::thread coro_thread(
+    [&]() { test_run_postprocess_scheduler(buffer, processor, std::move(timekeeper), delay_max_wait); });
 
   // Wait for coroutine to start then timeout to get registered
   while (timekeeper_ptr->numScheduled() == 0) {
     std::this_thread::sleep_for(1ms);
   }
-  // Safe-guard for the delay between timeout registration and coroutine suspension  
+  // Safe-guard for the delay between timeout registration and coroutine suspension
   // If the test is failing, consider a longer sleep or a better way to synchronize
   std::this_thread::sleep_for(1ms);
-  timekeeper_ptr->advance(std::chrono::milliseconds{ delay_max_wait }); // Trigger a timeout
+  timekeeper_ptr->advance(std::chrono::milliseconds(delay_max_wait)); // Trigger a timeout
 
-  model.set_run_marker(false); // Let coroutine end
-  coro_thread.join(); // The test will stuck here if timeout is not triggered (because of folly::coro::blockingWait)
+  set_run_marker(false); // Let coroutine end
+  coro_thread.join();    // The test will stuck here if timeout is not triggered (because of folly::coro::blockingWait)
 
-  BOOST_REQUIRE_EQUAL(model.get_num_post_processing_delay_max_waits(), 1);
+  BOOST_REQUIRE_EQUAL(get_num_post_processing_delay_max_waits(), 1);
 }
 
-BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgorithm_timeout)
+BOOST_AUTO_TEST_SUITE_END() // DataHandlingFixture
+
+BOOST_FIXTURE_TEST_SUITE(datahandlinglibs_DataHandlingModelPostprocessScheduleAlgorithm_test,
+                         PostprocessScheduleAlgorithmFixture)
+
+BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModelPostprocessScheduleAlgorithm_timeout)
 {
-  std::atomic<bool> run_marker = true;
+  std::vector<uint64_t> timestamps = {
+    1 * ms_to_ticks, 2 * ms_to_ticks, 3 * ms_to_ticks, 4 * ms_to_ticks, 5 * ms_to_ticks
+  }; // NOLINT(build/unsigned)
+  constexpr uint64_t delay_ticks = 4 * ms_to_ticks; // NOLINT(build/unsigned)
+  constexpr uint64_t delay_min_wait = 1;            // NOLINT(build/unsigned)
+  constexpr uint64_t delay_max_wait = 2;            // NOLINT(build/unsigned)
 
-  auto model =
-    unittest::MockDataHandlingModel<ReadoutType,
-                                    DefaultRequestHandlerModel<ReadoutType, SkipListLatencyBufferModel<ReadoutType>>,
-                                    SkipListLatencyBufferModel<ReadoutType>,
-                                    TaskRawDataProcessorModel<ReadoutType>>(run_marker);
-
-  auto buffer = std::make_shared<SkipListLatencyBufferModel<ReadoutType>>();
-
-  for (int i = 1; i < 6; i++) {
-    ReadoutType frame{};
-    frame.timestamp = i * 62500;
-    buffer->write(std::move(frame));
-  }
-
-  constexpr bool post_processing_enabled = true;
-  auto error_registry = std::make_unique<FrameErrorRegistry>();
-
-  auto raw_processor =
-    std::make_shared<TaskRawDataProcessorModel<ReadoutType>>(error_registry, post_processing_enabled);
-
-  constexpr uint64_t delay_ticks = 4 * 62500; // NOLINT(build/unsigned)
-  constexpr uint64_t delay_min_wait = 1; // NOLINT(build/unsigned)
-  constexpr uint64_t delay_max_wait = 2; // NOLINT(build/unsigned)
-
-  typename decltype(model)::PostprocessScheduleAlgorithm sched_algo{
-    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait
-  };
+  setup(delay_ticks, delay_min_wait, delay_max_wait, timestamps);
 
   // First pass
   bool timeout = false;
-  int processed_count = sched_algo.run(timeout);
+  int processed_count = run(timeout);
   // Buffer = {1, 2, 3, 4, 5} delay_ticks = 4
   // 5 - 1 > 4 is false => no postprocessing
   BOOST_REQUIRE_EQUAL(processed_count, 0);
@@ -109,84 +192,52 @@ BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgor
   timeout = true;
   // 1st timeout => timeout_accumulated = 1 * 2 (delay_max_wait = 2)
   // end_win_ts = 5 - 4 + 2 => postprocess until 3 {1, 2}
-  processed_count += sched_algo.run(timeout);
+  processed_count += run(timeout);
   BOOST_REQUIRE_EQUAL(processed_count, 2);
 
   // 2nd timeout => timeout_accumulated = 2 * 2
   // end_win_ts = 5 - 4 + 4 => postprocess until 5 {3, 4}
-  processed_count += sched_algo.run(timeout);
+  processed_count += run(timeout);
   BOOST_REQUIRE_EQUAL(processed_count, 4);
 
   // 3rd timeout => timeout_accumulated = 3 * 2
   // end_win_ts = 5 - 4 + 6 => postprocess until 6 (capped to newest_ts + 1) {5}
-  processed_count += sched_algo.run(timeout);
+  processed_count += run(timeout);
   BOOST_REQUIRE_EQUAL(processed_count, 5);
 
   // 4th timeout
   // m_processed_up_to.timestamp = newest_ts + 1 => nothing to postprocess (at cap)
-  processed_count += sched_algo.run(timeout);
+  processed_count += run(timeout);
   BOOST_REQUIRE_EQUAL(processed_count, 5);
 }
 
-BOOST_AUTO_TEST_CASE(datahandlinglibs_DataHandlingModel_PostprocessScheduleAlgorithm_data_arrives_after_fully_processed_with_timeout)
+BOOST_AUTO_TEST_CASE(
+  datahandlinglibs_DataHandlingModelPostprocessScheduleAlgorithm_data_arrives_after_fully_processed_with_timeout)
 {
-  std::atomic<bool> run_marker = true;
+  std::vector<uint64_t> timestamps = { 1 * ms_to_ticks, 2 * ms_to_ticks, 4 * ms_to_ticks }; // NOLINT(build/unsigned)
+  constexpr uint64_t delay_ticks = 1 * ms_to_ticks;                                         // NOLINT(build/unsigned)
+  constexpr uint64_t delay_min_wait = 1;                                                    // NOLINT(build/unsigned)
+  constexpr uint64_t delay_max_wait = 2;                                                    // NOLINT(build/unsigned)
 
-  auto model =
-    unittest::MockDataHandlingModel<ReadoutType,
-                                    DefaultRequestHandlerModel<ReadoutType, SkipListLatencyBufferModel<ReadoutType>>,
-                                    SkipListLatencyBufferModel<ReadoutType>,
-                                    TaskRawDataProcessorModel<ReadoutType>>(run_marker);
-
-  auto buffer = std::make_shared<SkipListLatencyBufferModel<ReadoutType>>();
-
-  for (int i = 1; i < 3; i++) {
-    ReadoutType frame{};
-    frame.timestamp = i * 62500;
-    buffer->write(std::move(frame));
-  }
-
-  {
-    ReadoutType frame{};
-    frame.timestamp = 4 * 62500;
-    buffer->write(std::move(frame));  
-  }
-
-  constexpr bool post_processing_enabled = true;
-  auto error_registry = std::make_unique<FrameErrorRegistry>();
-
-  auto raw_processor =
-    std::make_shared<TaskRawDataProcessorModel<ReadoutType>>(error_registry, post_processing_enabled);
-
-  constexpr uint64_t delay_ticks = 1 * 62500; // NOLINT(build/unsigned)
-  constexpr uint64_t delay_min_wait = 1; // NOLINT(build/unsigned)
-  constexpr uint64_t delay_max_wait = 2; // NOLINT(build/unsigned)
-
-  typename decltype(model)::PostprocessScheduleAlgorithm sched_algo{
-    *buffer, *raw_processor, delay_ticks, delay_min_wait, delay_max_wait
-  };
+  setup(delay_ticks, delay_min_wait, delay_max_wait, timestamps);
 
   bool timeout = true;
-  int processed_count = sched_algo.run(timeout);
+  int processed_count = run(timeout);
   // Buffer = {1, 2, 4} delay_ticks = 1
   // 1st timeout => timeout_accumulated = 1 * 2 (delay_max_wait = 2)
   // end_win_ts = 4 - 1 + 2 => postprocess until 5 {1, 2, 4}
   BOOST_REQUIRE_EQUAL(processed_count, 3);
 
-  {
-    ReadoutType frame{};
-    frame.timestamp = 3 * 62500;
-    buffer->write(std::move(frame));  
-  }
+  add_frame(3 * ms_to_ticks);
   // Buffer = {1, 2, 3, 4}
 
   // To not trigger the "too fast" case
   std::this_thread::sleep_for(std::chrono::milliseconds(delay_min_wait + 1));
 
   timeout = false;
-  // m_processed_up_to.timestamp = newest_ts + 1 => nothing to postprocess (data arrived too late)  
-  processed_count += sched_algo.run(timeout);
+  // m_processed_up_to.timestamp = newest_ts + 1 => nothing to postprocess (data arrived too late)
+  processed_count += run(timeout);
   BOOST_REQUIRE_EQUAL(processed_count, 3);
 }
 
-BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END() // PostprocessScheduleAlgorithmFixture


### PR DESCRIPTION
# Description

- Delayed postprocessing algorithm is refactored because it was missing a critical consideration in timeout case. That is, timeout counts should be per item, a single count is not enough to represent all items' waiting times, which can vary.

- 4 new monitoring variables are added.
```
  uint64 num_postprocess_late_arrivals; // Number of data arrivals for an already closed post-processing window
  uint64 max_postprocess_tick_diff_to_newest; // Maximum tick difference between late arrival and the newest item in the buffer since last monitoring
  uint64 max_postprocess_tick_diff_to_next_window_start; // Maximum tick difference between late arrival and the next processing window start since last monitoring
  uint64 max_postprocess_tick_diff_to_last_processed; // Maximum tick difference between late arrival and the last processed item since last monitoring
```
<img width="440" height="243" alt="delayedpp-diffs drawio(2)" src="https://github.com/user-attachments/assets/71b1fc51-637d-44e9-ab8e-00b13c86375f" />

- Added _ms suffix to wall-clock attributes of delayed postprocessing.

PS: These changes are meant for the next release. (Base branch will be changed to develop.)

[datahandlinglibs](https://github.com/DUNE-DAQ/datahandlinglibs/pull/132) dte/delayed_pp_monitoring
[appmodel](https://github.com/DUNE-DAQ/appmodel/pull/286) dte/delayedpp_attrs
[daqsystemtest](https://github.com/DUNE-DAQ/daqsystemtest/pull/311) dte/delayedpp_attrs
[snbmodules](https://github.com/DUNE-DAQ/snbmodules/pull/29) dte/delayedpp_attrs
[ehn1-daqconfigs](https://gitlab.cern.ch/dune-daq/online/ehn1-daqconfigs/-/merge_requests/279) dte/delayedpp_attrs

**Preliminary:** 

In the configuration, if `DataHandlerConf.post_processing_delay_ticks > 0`, postprocessing will be delayed. 
This feature is introduced for data streams that may arrive out of order; such data is stored in sorted buffers.
Using this delay, we allow time for late data to arrive and be sorted so that it can still be processed in order.

If delay ticks is set, DHL spawns a dedicated thread _pprocsched_ that runs the scheduler coroutine. The coroutine is woken up whenever data arrives.

In addition to delay ticks, one can also set `DataHandlerConf.post_processing_delay_max_wait > 0`. This enables the timeout feature of delayed postprocessing. With this feature, the coroutine wakes up not only when data arrives, but also if no data arrives within the specified duration.

One can also set `DataHandlerConf.post_processing_delay_min_wait` to enforce a minimum wait time before the next processing iteration.

**Delayed postprocessing algorithm:**

1. Return if buffer is empty.

2. Handle first cycle.

3. Return if postprocessing window is already closed.

    A (postprocessing) window is a subset of the buffer which will be processed.
    - It typically is only a part of the buffer. 
    - In data arrival case, it can contain, at most, the entire buffer except this arrival.
    - In timeout case, it can even contain the entire buffer.
    
    _Next window start_ is where to start processing in the next iteration. If it is greater than the newest item in the buffer, it means that the window was already closed.
    This happens if the entire buffer was already processed in a previous iteration and no newer data arrived since then.
    e.g. Buffer: {1, 3}. We already processed {1, 3}. Now {2} arrives. We notice this because next window start is {4} (_last processed + 1_) and `4 > 3`.  

4. In data arrival case, return if not enough time passed since last postprocessing. 

5. Return if _next window start_ cannot be found in the buffer. (Known issue with composite keys.)

6. Traverse the buffer and on the go:
 6.1. In timeout case, update (add 1 to) the _timeout count_ of the item.
 6.2. Check if it is too early to process this item. If so, mark this point as _window end_ and break the loop. (_Window end_ will be the _next window start_.)
 6.3. Otherwise, process the item and remove its _timeout count_ entry.

    Individual _timeout count_ entries keep track of timeout counts of not-yet-processed items. This is required because not every item waits in the buffer the same amount of time. This number will be used to decide if this item can be processed.

    An item can be processed if it is "old enough" relative to the newest timestamp. The _age difference_ must be bigger than the _delay ticks_ we configure; otherwise, it is too early to process. Timeouts artificially make items older; that is why, on top of the (real) _age difference_, we add the _virtual age_ of the item.

    _Virtual age_ of an item is calculated by multiplying its _timeout count_ by the _max wait_ we configure.

7. Only in the timeout case, it is possible that the entire buffer was processed.
 7.1. If so, the loop didn't break and _window end_ wasn't set. Set _window end_ to _last processed + 1_.
 7.2. Otherwise, traverse the rest of the buffer to update the remaining _timeout count_ s.

8. Make _window end_ the _next window start_.

<img width="866" height="1201" alt="delayedpp" src="https://github.com/user-attachments/assets/20bd30ee-c0e3-4b03-963c-b8eec91ed7e0" />

Addresses issue #116  

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

May need to also clone: `trigger`, `fdreadoutlibs` and `fdreadoutmodules`.

```
dbt-build --unittest datahandlinglibs
```

The following configuration parameters should be set for TP, TA and/or TC. Numbers can be different.
```
post_processing_delay_ticks = 312500;
post_processing_delay_min_wait = 1;
post_processing_delay_max_wait = 5;
```

[Example monitoring page](http://np04-srv-017:31023/d/aljzfpc/tp-post-processing?orgId=1&from=2026-04-08T14:05:38.254Z&to=2026-04-08T14:15:06.830Z&timezone=browser&var-influxdb=f68a27a2-f292-478c-8093-2a4adad3be1b&var-session=dte-delayedpp&var-application=$__all&var-tp_handler=$__all&refresh=10s&tab=queries&showCategory=Thresholds)

## Further checks

- [ ] Performance comparison
- [x] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
