### PR TITLE
Theo/ts rate fix

### DIFF
--- a/include/datahandlinglibs/models/SourceEmulatorModel.hpp
+++ b/include/datahandlinglibs/models/SourceEmulatorModel.hpp
@@ -156,9 +156,8 @@ private:
   // Pattern generator configs
   bool m_generate_periodic_adc_pattern;
   SourceEmulatorPatternGenerator m_pattern_generator;
-  uint64_t m_pattern_generator_previous_ts;
-  // Adding a hit every 9768 gives a TP rate of approx 100 Hz/wire using WIBEthernet
-  uint32_t m_time_to_wait = 9768;
+  // Adding a hit every 9766 gives a TP rate of approx 100 Hz/wire using WIBEthernet
+  uint32_t m_time_to_wait = 9766;
 };
 
 } // namespace datahandlinglibs

--- a/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
@@ -217,11 +217,7 @@ SourceEmulatorModel<ReadoutType>::run_produce()
             int time_sample = ((tp_call_counter / 64) % 32) * 2;
             ++tp_call_counter;
 
-            try {
-              payload.fake_adc_pattern(channel, time_sample);
-            } catch (std::exception& ex) {
-              // FIXME: should not happen
-            }
+            payload.fake_adc_pattern(channel, time_sample);
           }
 
           number_pattern_hits_generated += tps_this_frame;

--- a/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
@@ -208,12 +208,14 @@ SourceEmulatorModel<ReadoutType>::run_produce()
             tps_this_frame = max_tps_per_frame;
           }
 
-          // Distribute TPs across channels and time samples sequentially
-          // Channels cycle 0-63, time samples use even indices (0, 2, 4, ..., 62)
-          // This creates the alternating high/low ADC pattern needed for TP detection
+          // Distribute TPs across channels (via pattern generator) and time samples
+          // Channels are pseudo-random 0-63, time samples use even indices (0, 2, 4, ..., 62)
+          // tp_call_counter resets per frame; time_sample advances every 64 TPs within a frame
+          uint64_t tp_call_counter = 0;
           for (uint64_t tp_idx = 0; tp_idx < tps_this_frame; ++tp_idx) {
-            int channel = tp_idx % 64;
-            int time_sample = (tp_idx / 64) * 2;
+            int channel = m_pattern_generator.get_channel_number();
+            int time_sample = ((tp_call_counter / 64) % 32) * 2;
+            ++tp_call_counter;
 
             try {
               payload.fake_adc_pattern(channel, time_sample);

--- a/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
@@ -83,9 +83,9 @@ SourceEmulatorModel<ReadoutType>::conf(const confmodel::DetectorStream* link_con
       if (emu_params->get_TP_rate_per_channel() != 0) {
        TLOG() << "TP rate per channel multiplier (base of 100 Hz/ch): " << emu_params->get_TP_rate_per_channel();
        // Define time to wait when adding an ADC above threshold
-       // Adding a hit every 9768 gives a total Sent TP rate of approx 100 Hz/wire with WIBEth
-        m_time_to_wait = m_time_to_wait / emu_params->get_TP_rate_per_channel();
-      }
+       // Adding a hit every 9766 gives a total Sent TP rate of approx 100 Hz/wire with WIBEth
+        m_time_to_wait = m_time_to_wait / emu_params->get_TP_rate_per_channel();       
+      }  
     }
 
     m_is_configured = true;
@@ -160,6 +160,7 @@ SourceEmulatorModel<ReadoutType>::run_produce()
   TLOG_DEBUG(TLVL_BOOKKEEPING) << "Using first timestamp: " << ts_0;
   uint64_t timestamp = ts_0; // NOLINT(build/unsigned)
   int dropout_index = 0;
+  uint64_t number_pattern_hits_generated = 0;
 
   while (m_run_marker.load()) {
     // TLOG() << "Generating " << m_frames_per_tick << " for TS " << timestamp;
@@ -192,7 +193,9 @@ SourceEmulatorModel<ReadoutType>::run_produce()
         payload.fake_frame_errors(&frame_errs);
 
         if (m_generate_periodic_adc_pattern) {
-          if (timestamp - m_pattern_generator_previous_ts > m_time_to_wait) {
+          uint64_t number_pattern_hits_expected = (timestamp - ts_0) / m_time_to_wait;
+          while (number_pattern_hits_generated < number_pattern_hits_expected) {
+            ++number_pattern_hits_generated;
 
             /* Reset the pattern from the beginning if it reaches the maximum
             m_pattern_index++;
@@ -209,11 +212,8 @@ SourceEmulatorModel<ReadoutType>::run_produce()
             }
 
             //TLOG() << "Lift channel " << channel;
-
-            // Update the previous timestamp of the pattern generator
-            m_pattern_generator_previous_ts = timestamp;
-
-          } // timestamp difference
+            
+          } // (number_pattern_hits_expected - number_pattern_hits_generated) difference
         }
 
         // send it

--- a/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
@@ -194,26 +194,35 @@ SourceEmulatorModel<ReadoutType>::run_produce()
 
         if (m_generate_periodic_adc_pattern) {
           uint64_t number_pattern_hits_expected = (timestamp - ts_0) / m_time_to_wait;
-          while (number_pattern_hits_generated < number_pattern_hits_expected) {
-            ++number_pattern_hits_generated;
 
-            /* Reset the pattern from the beginning if it reaches the maximum
-            m_pattern_index++;
-            if (m_pattern_index == m_pattern_generator.get_total_size()) {
-              m_pattern_index = 0;
-            }
-            */
-            // Set the ADC to the uint16 maximum value
+          // Calculate how many TPs to generate in this frame
+          uint64_t tps_this_frame = 0;
+          if (number_pattern_hits_expected > number_pattern_hits_generated) {
+            tps_this_frame = number_pattern_hits_expected - number_pattern_hits_generated;
+          }
+
+          // Cap at maximum TPs per frame: 64 channels x 32 even time samples = 2048
+          // Each TP needs alternating ADC values (high/low), so only even time samples are used
+          const uint64_t max_tps_per_frame = 64 * 32;
+          if (tps_this_frame > max_tps_per_frame) {
+            tps_this_frame = max_tps_per_frame;
+          }
+
+          // Distribute TPs across channels and time samples sequentially
+          // Channels cycle 0-63, time samples use even indices (0, 2, 4, ..., 62)
+          // This creates the alternating high/low ADC pattern needed for TP detection
+          for (uint64_t tp_idx = 0; tp_idx < tps_this_frame; ++tp_idx) {
+            int channel = tp_idx % 64;
+            int time_sample = (tp_idx / 64) * 2;
+
             try {
-              payload.fake_adc_pattern(m_pattern_generator.get_channel_number());
+              payload.fake_adc_pattern(channel, time_sample);
+            } catch (std::exception& ex) {
+              // FIXME: should not happen
             }
-            catch (std::exception & ex) {
-              //FIXME: should not happen
-            }
+          }
 
-            //TLOG() << "Lift channel " << channel;
-            
-          } // (number_pattern_hits_expected - number_pattern_hits_generated) difference
+          number_pattern_hits_generated += tps_this_frame;
         }
 
         // send it


### PR DESCRIPTION
# Description

Addressing the issue #74 .

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Integration test note: daqsystemtest::3ru_1df_multirun_test                                      
                                                                               
  Across three sequential runs of this integration test, the         
  resulting HDF5 files contain 139, 140, and 140 trigger records respectively,  
  while the test expects 132.5 ± 6.5 (range 126.0–139.0). Two of the three runs 
  therefore overshoot the upper bound by 1 record and triggers the fail. All other 
  validations pass for these files. The remaining 5 of 6 
  subtests in 3ru_1df_multirun_test (WIBEth_System ×3, plus Software_TPG_System
  test_nanorc_success and test_log_files) pass, and example_system_test had transient connection issue and pass on rerun. The shift appears consistent. 

Note on Current develop branch:

max_file_size_test::test_tpstream_files failes by having 7 record files instead of 6. Same daqsystemtest::3ru_1df_multirun_test also persists.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

