### PR TITLE
Fixing TP rate adjustment

### DIFF
--- a/include/datahandlinglibs/models/SourceEmulatorModel.hpp
+++ b/include/datahandlinglibs/models/SourceEmulatorModel.hpp
@@ -31,6 +31,7 @@
 #include <functional>
 #include <memory>
 #include <random>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -156,7 +157,6 @@ private:
   // Pattern generator configs
   bool m_generate_periodic_adc_pattern;
   SourceEmulatorPatternGenerator m_pattern_generator;
-  uint64_t m_pattern_generator_previous_ts;
   // Adding a hit every 9768 gives a TP rate of approx 100 Hz/wire using WIBEthernet
   uint32_t m_time_to_wait = 9768;
 };

--- a/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/datahandlinglibs/models/detail/SourceEmulatorModel.hxx
@@ -160,6 +160,9 @@ SourceEmulatorModel<ReadoutType>::run_produce()
   TLOG_DEBUG(TLVL_BOOKKEEPING) << "Using first timestamp: " << ts_0;
   uint64_t timestamp = ts_0; // NOLINT(build/unsigned)
   int dropout_index = 0;
+  uint64_t number_pattern_hits_generated = 0;
+  // 64 total channels, placing on slot 0 gives 64 available slots.
+  const uint64_t max_tps_per_frame = 64;
 
   while (m_run_marker.load()) {
     // TLOG() << "Generating " << m_frames_per_tick << " for TS " << timestamp;
@@ -192,28 +195,34 @@ SourceEmulatorModel<ReadoutType>::run_produce()
         payload.fake_frame_errors(&frame_errs);
 
         if (m_generate_periodic_adc_pattern) {
-          if (timestamp - m_pattern_generator_previous_ts > m_time_to_wait) {
+          uint64_t number_pattern_hits_expected = (timestamp - ts_0) / m_time_to_wait;
 
-            /* Reset the pattern from the beginning if it reaches the maximum
-            m_pattern_index++;
-            if (m_pattern_index == m_pattern_generator.get_total_size()) {
-              m_pattern_index = 0;
-            }
-            */
-            // Set the ADC to the uint16 maximum value
+          // Calculate how many TPs to generate in this frame
+          uint64_t tps_this_frame = 0;
+          if (number_pattern_hits_expected > number_pattern_hits_generated) {
+            tps_this_frame = number_pattern_hits_expected - number_pattern_hits_generated;
+          }
+
+          if (tps_this_frame > max_tps_per_frame) {
+            tps_this_frame = max_tps_per_frame;
+          }
+
+          // Distribute TPs across channels via the pattern generator.
+          for (uint64_t tp_idx = 0; tp_idx < tps_this_frame; ++tp_idx) {
+            int channel = m_pattern_generator.get_channel_number();
+            // The pattern generator draws channel in range 0-63, current
+            // behaviour for frame type with 32 channels is silent dropping.
             try {
-              payload.fake_adc_pattern(m_pattern_generator.get_channel_number());
+              payload.fake_adc_pattern(channel);
             }
-            catch (std::exception & ex) {
-              //FIXME: should not happen
+            catch (const std::out_of_range&) {
             }
+          }
 
-            //TLOG() << "Lift channel " << channel;
-
-            // Update the previous timestamp of the pattern generator
-            m_pattern_generator_previous_ts = timestamp;
-
-          } // timestamp difference
+          // Count the number of patterns attempted to inject. Prevents
+          // expected - generated deficit from accumulating in case of
+          // injection failure.
+          number_pattern_hits_generated += tps_this_frame;
         }
 
         // send it


### PR DESCRIPTION
# Description

See issue #74 for details.

Fix the existing bug in the ADC pattern generation logic. Currently the emulator is attempting to sub-divide a timestamp interval to perform the required number of ADC pattern injection. The bug exists due to timestamp always increasing in integer steps.

New fix logic calculates the number of patterns that needs to be generated and calculate the deficit from the number of patterns needed. The difference is then scattered across channels. For example, needing 3 hits in one frame means that they could be scattered across channels 0, 42, 63 (channel selection is from `m_pattern_generator.get_channel_number())`).

Known limitation: All patterns are placed on the first time sample. Therefore, it limits the max number of hits to place in one frame to be 64 (number of channels).

Realistically, filling all these slots corresponds to a rate of

r = 64 × 9768 / 2048 = 305.25, which is 300 times above the nominal 1 Hz rate.

This PR therefore keeps placing adc pulse only on first time sample. If this needs extension in the future, `fake_adc_pattern` signature would need a small change to accept a second time sample argument.

During the development, a related bug regarding CRT frames and its limitation of 32 channels was identified. It is deemed a separate issue from this PR and recorded in issue (TBD). The existing try catch block remains although I have tightened it a bit to catch the actual error and also make it per statement rather than the entire sending block.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

The current set of unit tests would fail at `max_file_size` test. This is exactly due to the behaviour change introduced by this PR. At a set rate of 5 Hz, this PR's version generate 1.048x more TPs, where the 4.8% extra results in a new 32 MB record file that fails the check for 6 record files (now 7). This is overcome by replacing the set rate from 5 Hz to 4.65 Hz. The 4.65 Hz version of the integration test passes with exactly 6 record files.

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [x] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

