### PR TITLE
Bump version to 3.2.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(datahandlinglibs VERSION 3.2.5)
+project(datahandlinglibs VERSION 3.2.6)
 
 find_package(daq-cmake REQUIRED)
 


### PR DESCRIPTION
Bump version to 3.2.6

Brief summary of changes: Fix ADC pattern-generation rate/timestamp drift bug in `SourceEmulatorModel`.

> [!IMPORTANT]
> Tag `v3.2.6` has already been pushed and points at the head commit of this
> branch. **Please merge this PR with a merge commit — do not squash or rebase.**
> Squashing or rebasing would leave the published tag pointing at a commit that
> is not an ancestor of `prep-release/fddaq-v5.7.0`.
